### PR TITLE
feat: bootstrap Riff foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    name: fmt, clippy, test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Test
+        run: cargo test --all-features
+
+      - name: Check
+        run: cargo check --all-targets --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,5 +2,12 @@
 name = "riff"
 version = "0.1.0"
 edition = "2024"
+description = "A terminal-first music player where playlists are code."
+license = "MIT"
+repository = "https://github.com/Nicolas25vlad/riff"
+homepage = "https://github.com/Nicolas25vlad/riff"
+readme = "README.md"
+keywords = ["music", "spotify", "terminal", "tui", "rust"]
+categories = ["command-line-utilities", "multimedia::audio"]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,338 @@
-# riff
-A terminal-first Spotify player where playlists are code. Built with Rust, librespot and Ratatui.
+<div align="center">
+  <img src="assets/riff-logo.svg" alt="Riff logo" width="720" />
+
+  <p><strong>Music as code. Spotify in your terminal.</strong></p>
+  <p>A terminal-first music player written in Rust, designed around declarative, versionable playlists.</p>
+
+  <p>
+    <a href="https://github.com/Nicolas25vlad/riff/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/Nicolas25vlad/riff/actions/workflows/ci.yml/badge.svg" /></a>
+    <img alt="Rust" src="https://img.shields.io/badge/Rust-2024-orange?logo=rust" />
+    <img alt="License" src="https://img.shields.io/github/license/Nicolas25vlad/riff" />
+    <img alt="Status" src="https://img.shields.io/badge/status-early%20development-yellow" />
+  </p>
+</div>
+
+---
+
+## What is Riff?
+
+Riff is an experiment in treating your music library the way developers treat infrastructure and configuration.
+
+Instead of building every playlist by clicking through a GUI, you describe it in a small text format, keep it beside your dotfiles, review changes with `git diff`, share it on GitHub, and eventually let Riff resolve and play it through Spotify.
+
+```riff
+playlist "coding-metal" {
+    track "Black Sabbath - War Pigs"
+    track "Dio - Holy Diver"
+    track "Metallica - Orion"
+    track "Megadeth - Tornado of Souls"
+}
+```
+
+```console
+$ riff validate examples/coding-metal.riff
+✓ coding-metal is valid (4 tracks)
+
+$ riff inspect examples/coding-metal.riff
+coding-metal
+4 tracks
+
+  1. Black Sabbath - War Pigs
+  2. Dio - Holy Diver
+  3. Metallica - Orion
+  4. Megadeth - Tornado of Souls
+```
+
+The long-term goal is a complete terminal music experience powered by Rust, `librespot`, Ratatui and a declarative playlist engine.
+
+## Why?
+
+Spotify playlists are useful, but they are mostly opaque application state. Riff explores a different model:
+
+- **Playlists as source code**: readable text files with deterministic ordering.
+- **Git-native music libraries**: branch, diff, review, fork and share playlists like code.
+- **Terminal-first playback**: search, queue, play, pause and navigate without leaving your shell.
+- **Native Spotify playback**: use `librespot` so Riff can eventually act as its own Spotify Connect device.
+- **Rich terminal UI**: album artwork, queue management, playback state and audio visualization.
+- **Provider-independent core**: Spotify first, without making the playlist language permanently Spotify-specific.
+
+## Vision
+
+The end state should feel less like a thin Spotify wrapper and more like a tiny music operating environment for the terminal.
+
+```text
+┌──────────────────────────────────────────────────────────────┐
+│ RIFF                                              03:21 / 07:57│
+├──────────────────────┬───────────────────────────────────────┤
+│                      │ Black Sabbath                         │
+│    [ album art ]     │ War Pigs                              │
+│                      │ Paranoid                              │
+│                      │                                       │
+│                      │ ▁▂▃▅▇▅▃▂▂▃▆██▆▄▃▂▁▂▅▇██▅▂           │
+├──────────────────────┴───────────────────────────────────────┤
+│ Queue                                                        │
+│ > War Pigs                                                   │
+│   Holy Diver                                                 │
+│   Orion                                                       │
+│   Tornado of Souls                                           │
+├──────────────────────────────────────────────────────────────┤
+│ j/k move   space pause   n next   / search   : command       │
+└──────────────────────────────────────────────────────────────┘
+```
+
+The audio path is planned around decoded PCM from `librespot`, which lets playback and visualization share the same stream:
+
+```text
+.riff files
+    │
+    ▼
+ parser / AST
+    │
+    ▼
+ playlist engine ───────► provider resolution
+                              │
+                              ▼
+                           librespot
+                              │
+                           decoded PCM
+                           ╱         ╲
+                          ▼           ▼
+                    audio output   FFT/analyzer
+                                      │
+                                      ▼
+                                  visualizer
+```
+
+## Current status
+
+Riff is in **early development**. The repository currently contains the first intentionally small foundation:
+
+- a dependency-free Rust CLI core;
+- `riff doctor`;
+- `riff validate <file>`;
+- `riff inspect <file>`;
+- the first parser for the `.riff` playlist format;
+- parser tests;
+- CI for formatting, Clippy, tests and `cargo check`.
+
+There is no Spotify playback yet. The initial parser is deliberately tiny so the language can evolve from a clear grammar instead of accreting random syntax.
+
+## Planned playlist language
+
+The current implementation only supports explicit `track` statements. The eventual language is intended to become expressive enough to describe both static playlists and reproducible selection rules.
+
+```riff
+playlist "night-shift" {
+    add artist("Black Sabbath").top(8)
+    add album("Holy Diver", by="Dio")
+
+    add artist("Megadeth")
+        .take(5)
+        .shuffle(seed=666)
+
+    exclude live
+    exclude acoustic
+}
+```
+
+The important property is reproducibility. A seeded or otherwise deterministic playlist definition should resolve to the same ordering when possible.
+
+Eventually, Riff should be able to show playlist changes before applying them:
+
+```diff
+coding-metal
+
++ Dio - Holy Diver
++ Black Sabbath - Supernaut
+- Metallica - Fuel
+
+Plan: 2 to add, 1 to remove, 4 to reorder
+```
+
+```console
+$ riff apply
+✓ coding-metal synchronized
+```
+
+Yes, the aspiration is essentially **Terraform for playlists**, with significantly more guitar riffs.
+
+## CLI
+
+Available today:
+
+```text
+riff doctor
+riff validate <file>
+riff inspect <file>
+riff help
+riff version
+```
+
+Planned commands include:
+
+```text
+riff play [playlist|track]
+riff pause
+riff next
+riff previous
+riff search <query>
+riff queue add <query>
+riff status
+riff apply
+riff tui
+```
+
+## Getting started
+
+### Requirements
+
+- Rust stable with Cargo
+- Git
+
+Clone and run:
+
+```bash
+git clone https://github.com/Nicolas25vlad/riff.git
+cd riff
+cargo run -- doctor
+```
+
+Try the example playlist:
+
+```bash
+cargo run -- validate examples/coding-metal.riff
+cargo run -- inspect examples/coding-metal.riff
+```
+
+Run the quality suite:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-features
+cargo check --all-targets --all-features
+```
+
+## Architecture
+
+The project is intentionally still a single crate while its public concepts settle. Splitting into a workspace too early would freeze boundaries we have not earned yet.
+
+The intended evolution is roughly:
+
+```text
+riff/
+├── riff-cli          command-line interface
+├── riff-core         playback state, queue and domain model
+├── riff-lang         lexer, parser and playlist AST
+├── riff-provider     provider abstraction
+├── riff-spotify      Spotify/librespot integration
+├── riff-audio        PCM pipeline and audio output
+├── riff-visualizer   FFT, spectrum, waveform and meters
+├── riff-image        terminal image protocols and fallbacks
+└── riff-tui          Ratatui application
+```
+
+Likely technologies as the project grows:
+
+| Area | Direction |
+| --- | --- |
+| Language | Rust |
+| Spotify playback | librespot |
+| Terminal UI | Ratatui + Crossterm |
+| Async runtime | Tokio |
+| Local state/cache | SQLite |
+| Audio analysis | FFT over decoded PCM |
+| Cover art | Kitty graphics / Sixel / Unicode fallback |
+| Playlist language | custom parser + typed AST |
+
+Nothing in that table should be considered a permanent dependency commitment yet. Riff should earn complexity one feature at a time.
+
+## Roadmap
+
+### v0.1 · Foundation
+
+- [x] Project identity and documentation
+- [x] Minimal CLI
+- [x] First `.riff` parser
+- [x] Playlist validation and inspection
+- [x] Unit tests and CI
+- [ ] Formalize the first grammar
+- [ ] Better diagnostics with line/column information
+
+### v0.2 · Spotify core
+
+- [ ] Authentication/session management
+- [ ] Track search and metadata resolution
+- [ ] `librespot` playback
+- [ ] Spotify Connect device mode
+- [ ] Play, pause, seek, next and previous
+
+### v0.3 · Terminal player
+
+- [ ] Ratatui interface
+- [ ] Queue browser
+- [ ] Search view
+- [ ] Album artwork
+- [ ] Configurable keybindings
+
+### v0.4 · Audio candy
+
+- [ ] PCM analysis pipeline
+- [ ] Spectrum visualizer
+- [ ] Waveform / oscilloscope mode
+- [ ] VU meter
+- [ ] Theme extraction from album covers
+
+### v0.5 · Music as code
+
+- [ ] Expressions and reusable playlist fragments
+- [ ] Deterministic shuffle seeds
+- [ ] Filters and exclusions
+- [ ] Imports
+- [ ] Provider-independent track references
+- [ ] `riff plan`
+- [ ] `riff apply`
+
+## Design principles
+
+1. **Terminal first, not terminal only.** The CLI should remain scriptable even when the TUI becomes rich.
+2. **Text files are the source of truth.** A playlist should be understandable without launching Riff.
+3. **Determinism where possible.** Music definitions should be reproducible enough to meaningfully version.
+4. **Fast startup matters.** A terminal player that feels heavy has missed the point.
+5. **Keep provider concerns isolated.** The language should describe music, not leak Spotify internals everywhere.
+6. **No architecture cosplay.** Crates, traits and abstractions appear when they solve real problems.
+
+## Contributing
+
+Riff is extremely young, which means design discussion is currently as valuable as code.
+
+Before implementing a large subsystem, open an issue describing the proposed behavior and how it fits the project. Small fixes, tests and documentation improvements can go directly to a pull request.
+
+Basic workflow:
+
+```bash
+git checkout -b feat/my-feature
+cargo fmt
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test
+```
+
+Please keep commits focused and prefer tests around parser behavior and state transitions.
+
+## Name
+
+A **riff** is a short musical phrase that gives a song identity. It also happens to be short, terminal-friendly, and looks suspiciously appropriate next to a Rust crab.
+
+## Disclaimer
+
+Riff is an independent open-source project and is not affiliated with, endorsed by, or sponsored by Spotify AB. Spotify is a trademark of Spotify AB.
+
+Spotify-specific functionality planned for Riff may require Spotify Premium and will depend on the capabilities and compatibility of `librespot` and Spotify's services at the time of implementation.
+
+## License
+
+Riff is released under the [MIT License](LICENSE).
+
+<div align="center">
+  <strong>Write playlists. Commit them. Play them.</strong>
+</div>

--- a/assets/riff-logo.svg
+++ b/assets/riff-logo.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="280" viewBox="0 0 960 280" role="img" aria-labelledby="title desc">
+  <title id="title">Riff logo</title>
+  <desc id="desc">A terminal-inspired Riff wordmark with an audio waveform.</desc>
+  <rect width="960" height="280" rx="32" fill="#0d1117"/>
+  <g transform="translate(72 56)" fill="none" stroke="#7ee787" stroke-width="12" stroke-linecap="round">
+    <path d="M0 84h24l18-44 28 88 28-120 28 152 28-104 28 56 18-28h28"/>
+  </g>
+  <text x="330" y="148" fill="#f0f6fc" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="104" font-weight="700" letter-spacing="8">RIFF</text>
+  <text x="334" y="202" fill="#8b949e" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="26">music as code • terminal first</text>
+</svg>

--- a/examples/coding-metal.riff
+++ b/examples/coding-metal.riff
@@ -1,0 +1,7 @@
+# Riff playlist example
+playlist "coding-metal" {
+    track "Black Sabbath - War Pigs"
+    track "Dio - Holy Diver"
+    track "Metallica - Orion"
+    track "Megadeth - Tornado of Souls"
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,11 +14,15 @@ impl Command {
         match args {
             [] => Ok(Self::Help),
             [flag] if flag == "-h" || flag == "--help" || flag == "help" => Ok(Self::Help),
-            [flag] if flag == "-V" || flag == "--version" || flag == "version" => Ok(Self::Version),
+            [flag] if flag == "-V" || flag == "--version" || flag == "version" => {
+                Ok(Self::Version)
+            }
             [cmd] if cmd == "doctor" => Ok(Self::Doctor),
             [cmd, path] if cmd == "validate" => Ok(Self::Validate(path.into())),
             [cmd, path] if cmd == "inspect" => Ok(Self::Inspect(path.into())),
-            _ => Err(RiffError::Usage("unknown command or invalid arguments".into())),
+            _ => Err(RiffError::Usage(
+                "unknown command or invalid arguments".into(),
+            )),
         }
     }
 }
@@ -31,8 +35,13 @@ pub struct Playlist {
 
 impl Playlist {
     pub fn parse(source: &str) -> Result<Self, RiffError> {
-        let mut lines = source.lines().map(str::trim).filter(|line| !line.is_empty() && !line.starts_with('#'));
-        let header = lines.next().ok_or_else(|| RiffError::Parse("missing playlist declaration".into()))?;
+        let mut lines = source
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty() && !line.starts_with('#'));
+        let header = lines
+            .next()
+            .ok_or_else(|| RiffError::Parse("missing playlist declaration".into()))?;
 
         if !header.starts_with("playlist ") || !header.ends_with('{') {
             return Err(RiffError::Parse("expected `playlist \"name\" {`".into()));
@@ -67,7 +76,9 @@ impl Playlist {
                 continue;
             }
 
-            return Err(RiffError::Parse(format!("unsupported statement: `{line}`")));
+            return Err(RiffError::Parse(format!(
+                "unsupported statement: `{line}`"
+            )));
         }
 
         if !closed {
@@ -109,7 +120,11 @@ pub fn run(command: Command) -> Result<String, RiffError> {
         Command::Validate(path) => {
             let source = fs::read_to_string(&path)?;
             let playlist = Playlist::parse(&source)?;
-            Ok(format!("✓ {} is valid ({} tracks)", playlist.name, playlist.tracks.len()))
+            Ok(format!(
+                "✓ {} is valid ({} tracks)",
+                playlist.name,
+                playlist.tracks.len()
+            ))
         }
         Command::Inspect(path) => {
             let source = fs::read_to_string(&path)?;
@@ -121,7 +136,12 @@ pub fn run(command: Command) -> Result<String, RiffError> {
                 .map(|(index, track)| format!("{:>3}. {track}", index + 1))
                 .collect::<Vec<_>>()
                 .join("\n");
-            Ok(format!("{}\n{} tracks\n\n{}", playlist.name, playlist.tracks.len(), body))
+            Ok(format!(
+                "{}\n{} tracks\n\n{}",
+                playlist.name,
+                playlist.tracks.len(),
+                body
+            ))
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,167 @@
+use std::{fmt, fs, path::PathBuf};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Command {
+    Help,
+    Version,
+    Doctor,
+    Validate(PathBuf),
+    Inspect(PathBuf),
+}
+
+impl Command {
+    pub fn parse(args: &[String]) -> Result<Self, RiffError> {
+        match args {
+            [] => Ok(Self::Help),
+            [flag] if flag == "-h" || flag == "--help" || flag == "help" => Ok(Self::Help),
+            [flag] if flag == "-V" || flag == "--version" || flag == "version" => Ok(Self::Version),
+            [cmd] if cmd == "doctor" => Ok(Self::Doctor),
+            [cmd, path] if cmd == "validate" => Ok(Self::Validate(path.into())),
+            [cmd, path] if cmd == "inspect" => Ok(Self::Inspect(path.into())),
+            _ => Err(RiffError::Usage("unknown command or invalid arguments".into())),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Playlist {
+    pub name: String,
+    pub tracks: Vec<String>,
+}
+
+impl Playlist {
+    pub fn parse(source: &str) -> Result<Self, RiffError> {
+        let mut lines = source.lines().map(str::trim).filter(|line| !line.is_empty() && !line.starts_with('#'));
+        let header = lines.next().ok_or_else(|| RiffError::Parse("missing playlist declaration".into()))?;
+
+        if !header.starts_with("playlist ") || !header.ends_with('{') {
+            return Err(RiffError::Parse("expected `playlist \"name\" {`".into()));
+        }
+
+        let name = header
+            .trim_start_matches("playlist ")
+            .trim_end_matches('{')
+            .trim()
+            .trim_matches('"')
+            .to_string();
+
+        if name.is_empty() {
+            return Err(RiffError::Parse("playlist name cannot be empty".into()));
+        }
+
+        let mut tracks = Vec::new();
+        let mut closed = false;
+
+        for line in lines {
+            if line == "}" {
+                closed = true;
+                break;
+            }
+
+            if let Some(value) = line.strip_prefix("track ") {
+                let value = value.trim().trim_matches('"');
+                if value.is_empty() {
+                    return Err(RiffError::Parse("track cannot be empty".into()));
+                }
+                tracks.push(value.to_string());
+                continue;
+            }
+
+            return Err(RiffError::Parse(format!("unsupported statement: `{line}`")));
+        }
+
+        if !closed {
+            return Err(RiffError::Parse("playlist block is not closed".into()));
+        }
+
+        Ok(Self { name, tracks })
+    }
+}
+
+#[derive(Debug)]
+pub enum RiffError {
+    Io(std::io::Error),
+    Parse(String),
+    Usage(String),
+}
+
+impl fmt::Display for RiffError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(err) => write!(f, "{err}"),
+            Self::Parse(msg) => write!(f, "parse error: {msg}"),
+            Self::Usage(msg) => write!(f, "{msg}\n\n{}", help()),
+        }
+    }
+}
+
+impl From<std::io::Error> for RiffError {
+    fn from(value: std::io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+pub fn run(command: Command) -> Result<String, RiffError> {
+    match command {
+        Command::Help => Ok(help()),
+        Command::Version => Ok(format!("riff {}", env!("CARGO_PKG_VERSION"))),
+        Command::Doctor => Ok(doctor()),
+        Command::Validate(path) => {
+            let source = fs::read_to_string(&path)?;
+            let playlist = Playlist::parse(&source)?;
+            Ok(format!("✓ {} is valid ({} tracks)", playlist.name, playlist.tracks.len()))
+        }
+        Command::Inspect(path) => {
+            let source = fs::read_to_string(&path)?;
+            let playlist = Playlist::parse(&source)?;
+            let body = playlist
+                .tracks
+                .iter()
+                .enumerate()
+                .map(|(index, track)| format!("{:>3}. {track}", index + 1))
+                .collect::<Vec<_>>()
+                .join("\n");
+            Ok(format!("{}\n{} tracks\n\n{}", playlist.name, playlist.tracks.len(), body))
+        }
+    }
+}
+
+pub fn help() -> String {
+    format!(
+        "riff {}\nMusic as code, from the terminal.\n\nUSAGE:\n  riff <COMMAND>\n\nCOMMANDS:\n  doctor           Check the local Riff environment\n  validate <file>  Validate a .riff playlist\n  inspect <file>   Parse and print a .riff playlist\n  help             Print this help\n  version          Print version",
+        env!("CARGO_PKG_VERSION")
+    )
+}
+
+fn doctor() -> String {
+    format!(
+        "Riff doctor\n  version      {}\n  rust target  {}\n  playlist DSL ready\n  spotify      not configured yet\n  playback     not implemented yet",
+        env!("CARGO_PKG_VERSION"),
+        std::env::consts::ARCH
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_minimal_playlist() {
+        let source = r#"
+            playlist "coding-metal" {
+                track "Black Sabbath - War Pigs"
+                track "Dio - Holy Diver"
+            }
+        "#;
+
+        let playlist = Playlist::parse(source).expect("playlist should parse");
+        assert_eq!(playlist.name, "coding-metal");
+        assert_eq!(playlist.tracks.len(), 2);
+    }
+
+    #[test]
+    fn rejects_unknown_statement() {
+        let source = "playlist \"x\" {\nshuffle true\n}";
+        assert!(Playlist::parse(source).is_err());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,7 @@ impl Command {
         match args {
             [] => Ok(Self::Help),
             [flag] if flag == "-h" || flag == "--help" || flag == "help" => Ok(Self::Help),
-            [flag] if flag == "-V" || flag == "--version" || flag == "version" => {
-                Ok(Self::Version)
-            }
+            [flag] if flag == "-V" || flag == "--version" || flag == "version" => Ok(Self::Version),
             [cmd] if cmd == "doctor" => Ok(Self::Doctor),
             [cmd, path] if cmd == "validate" => Ok(Self::Validate(path.into())),
             [cmd, path] if cmd == "inspect" => Ok(Self::Inspect(path.into())),
@@ -76,9 +74,7 @@ impl Playlist {
                 continue;
             }
 
-            return Err(RiffError::Parse(format!(
-                "unsupported statement: `{line}`"
-            )));
+            return Err(RiffError::Parse(format!("unsupported statement: `{line}`")));
         }
 
         if !closed {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,19 @@
+use std::{env, process};
+
+use riff::{Command, run};
+
 fn main() {
-    println!("Hello, world!");
+    let args: Vec<String> = env::args().skip(1).collect();
+
+    match Command::parse(&args).and_then(run) {
+        Ok(output) => {
+            if !output.is_empty() {
+                println!("{output}");
+            }
+        }
+        Err(err) => {
+            eprintln!("riff: {err}");
+            process::exit(1);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Bootstraps Riff as a real Rust project instead of a placeholder binary.

### Code
- replaces `Hello, world!` with a small dependency-free CLI core
- adds `riff doctor`
- adds `riff validate <file>`
- adds `riff inspect <file>`
- introduces the first `.riff` playlist parser
- adds parser unit tests
- adds an example playlist

### Project quality
- adds crate metadata
- adds GitHub Actions CI for fmt, Clippy, tests and `cargo check`

### Documentation / identity
- adds an original SVG Riff logo
- completely rebuilds the README with project vision, examples, architecture, roadmap, design principles, contribution workflow and disclaimer
- documents the planned librespot + Ratatui + PCM visualizer architecture without pretending those parts already exist

## Philosophy

This intentionally keeps v0.1 small and dependency-free. The project should earn architectural complexity as the Spotify, playback and TUI boundaries become concrete.

## Next step

After this lands, the next focused PR should formalize the playlist grammar and diagnostics before integrating Spotify playback.