### PR TITLE
feat: make v0.1 install-ready

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,8 @@ keywords = ["music", "spotify", "terminal", "tui", "rust"]
 categories = ["command-line-utilities", "multimedia::audio"]
 
 [dependencies]
+
+[profile.release]
+strip = true
+lto = "thin"
+codegen-units = 1

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,104 @@
+# Installing Riff
+
+Riff is currently distributed straight from GitHub while the project is in early development.
+
+## Install with Cargo
+
+Requirements:
+
+- Git
+- Rust stable and Cargo
+
+Install the latest `main` build:
+
+```bash
+cargo install --git https://github.com/Nicolas25vlad/riff --locked
+```
+
+Make sure Cargo's binary directory is on your `PATH`:
+
+```bash
+export PATH="$HOME/.cargo/bin:$PATH"
+```
+
+For Fish:
+
+```fish
+fish_add_path $HOME/.cargo/bin
+```
+
+Verify the installation:
+
+```bash
+riff --version
+riff doctor
+```
+
+## First run
+
+Create a starter playlist:
+
+```bash
+riff init
+```
+
+That creates `playlist.riff` in the current directory:
+
+```riff
+playlist "my-playlist" {
+    track "Black Sabbath - War Pigs"
+    track "Dio - Holy Diver"
+}
+```
+
+Validate it:
+
+```bash
+riff validate playlist.riff
+```
+
+Inspect the parsed playlist:
+
+```bash
+riff inspect playlist.riff
+```
+
+You can also choose the file name when initializing:
+
+```bash
+riff init coding-metal.riff
+```
+
+Riff refuses to overwrite an existing file.
+
+## Update
+
+Until packaged releases are available, update by reinstalling from GitHub:
+
+```bash
+cargo install --git https://github.com/Nicolas25vlad/riff --locked --force
+```
+
+## Uninstall
+
+```bash
+cargo uninstall riff
+```
+
+## Build from source
+
+```bash
+git clone https://github.com/Nicolas25vlad/riff.git
+cd riff
+cargo build --release
+```
+
+The resulting binary will be available at:
+
+```text
+target/release/riff
+```
+
+## Current limitations
+
+The current v0.1 foundation implements the playlist DSL tooling only. Spotify authentication, `librespot` playback, the Ratatui interface, album art and audio visualization are planned but are not implemented yet.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "stable"
+components = ["clippy", "rustfmt"]
+profile = "minimal"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,17 @@
 use std::{fmt, fs, path::PathBuf};
 
+const DEFAULT_PLAYLIST: &str = r#"playlist \"my-playlist\" {
+    track \"Black Sabbath - War Pigs\"
+    track \"Dio - Holy Diver\"
+}
+"#;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Command {
     Help,
     Version,
     Doctor,
+    Init(PathBuf),
     Validate(PathBuf),
     Inspect(PathBuf),
 }
@@ -16,6 +23,8 @@ impl Command {
             [flag] if flag == "-h" || flag == "--help" || flag == "help" => Ok(Self::Help),
             [flag] if flag == "-V" || flag == "--version" || flag == "version" => Ok(Self::Version),
             [cmd] if cmd == "doctor" => Ok(Self::Doctor),
+            [cmd] if cmd == "init" => Ok(Self::Init("playlist.riff".into())),
+            [cmd, path] if cmd == "init" => Ok(Self::Init(path.into())),
             [cmd, path] if cmd == "validate" => Ok(Self::Validate(path.into())),
             [cmd, path] if cmd == "inspect" => Ok(Self::Inspect(path.into())),
             _ => Err(RiffError::Usage(
@@ -37,25 +46,12 @@ impl Playlist {
             .lines()
             .map(str::trim)
             .filter(|line| !line.is_empty() && !line.starts_with('#'));
+
         let header = lines
             .next()
             .ok_or_else(|| RiffError::Parse("missing playlist declaration".into()))?;
 
-        if !header.starts_with("playlist ") || !header.ends_with('{') {
-            return Err(RiffError::Parse("expected `playlist \"name\" {`".into()));
-        }
-
-        let name = header
-            .trim_start_matches("playlist ")
-            .trim_end_matches('{')
-            .trim()
-            .trim_matches('"')
-            .to_string();
-
-        if name.is_empty() {
-            return Err(RiffError::Parse("playlist name cannot be empty".into()));
-        }
-
+        let name = parse_playlist_header(header)?;
         let mut tracks = Vec::new();
         let mut closed = false;
 
@@ -65,24 +61,57 @@ impl Playlist {
                 break;
             }
 
-            if let Some(value) = line.strip_prefix("track ") {
-                let value = value.trim().trim_matches('"');
-                if value.is_empty() {
-                    return Err(RiffError::Parse("track cannot be empty".into()));
-                }
-                tracks.push(value.to_string());
-                continue;
+            let value = line
+                .strip_prefix("track ")
+                .ok_or_else(|| RiffError::Parse(format!("unsupported statement: `{line}`")))?;
+
+            let track = parse_quoted(value, "track")?;
+            if track.is_empty() {
+                return Err(RiffError::Parse("track cannot be empty".into()));
             }
 
-            return Err(RiffError::Parse(format!("unsupported statement: `{line}`")));
+            tracks.push(track.to_string());
         }
 
         if !closed {
             return Err(RiffError::Parse("playlist block is not closed".into()));
         }
 
-        Ok(Self { name, tracks })
+        if lines.next().is_some() {
+            return Err(RiffError::Parse(
+                "unexpected content after playlist block".into(),
+            ));
+        }
+
+        Ok(Self {
+            name: name.to_string(),
+            tracks,
+        })
     }
+}
+
+fn parse_playlist_header(header: &str) -> Result<&str, RiffError> {
+    let value = header
+        .strip_prefix("playlist ")
+        .and_then(|value| value.strip_suffix('{'))
+        .map(str::trim)
+        .ok_or_else(|| RiffError::Parse("expected `playlist \"name\" {`".into()))?;
+
+    let name = parse_quoted(value, "playlist name")?;
+    if name.is_empty() {
+        return Err(RiffError::Parse("playlist name cannot be empty".into()));
+    }
+
+    Ok(name)
+}
+
+fn parse_quoted<'a>(value: &'a str, label: &str) -> Result<&'a str, RiffError> {
+    let value = value.trim();
+    if value.len() < 2 || !value.starts_with('"') || !value.ends_with('"') {
+        return Err(RiffError::Parse(format!("{label} must be quoted")));
+    }
+
+    Ok(&value[1..value.len() - 1])
 }
 
 #[derive(Debug)]
@@ -90,6 +119,7 @@ pub enum RiffError {
     Io(std::io::Error),
     Parse(String),
     Usage(String),
+    AlreadyExists(PathBuf),
 }
 
 impl fmt::Display for RiffError {
@@ -98,6 +128,11 @@ impl fmt::Display for RiffError {
             Self::Io(err) => write!(f, "{err}"),
             Self::Parse(msg) => write!(f, "parse error: {msg}"),
             Self::Usage(msg) => write!(f, "{msg}\n\n{}", help()),
+            Self::AlreadyExists(path) => write!(
+                f,
+                "{} already exists; choose another path or remove it first",
+                path.display()
+            ),
         }
     }
 }
@@ -113,6 +148,7 @@ pub fn run(command: Command) -> Result<String, RiffError> {
         Command::Help => Ok(help()),
         Command::Version => Ok(format!("riff {}", env!("CARGO_PKG_VERSION"))),
         Command::Doctor => Ok(doctor()),
+        Command::Init(path) => init(path),
         Command::Validate(path) => {
             let source = fs::read_to_string(&path)?;
             let playlist = Playlist::parse(&source)?;
@@ -132,27 +168,47 @@ pub fn run(command: Command) -> Result<String, RiffError> {
                 .map(|(index, track)| format!("{:>3}. {track}", index + 1))
                 .collect::<Vec<_>>()
                 .join("\n");
-            Ok(format!(
-                "{}\n{} tracks\n\n{}",
-                playlist.name,
-                playlist.tracks.len(),
-                body
-            ))
+
+            if body.is_empty() {
+                Ok(format!("{}\n0 tracks", playlist.name))
+            } else {
+                Ok(format!(
+                    "{}\n{} tracks\n\n{}",
+                    playlist.name,
+                    playlist.tracks.len(),
+                    body
+                ))
+            }
         }
     }
 }
 
+fn init(path: PathBuf) -> Result<String, RiffError> {
+    if path.exists() {
+        return Err(RiffError::AlreadyExists(path));
+    }
+
+    fs::write(&path, DEFAULT_PLAYLIST)?;
+    Ok(format!(
+        "✓ created {}\n\nNext:\n  riff validate {}\n  riff inspect {}",
+        path.display(),
+        path.display(),
+        path.display()
+    ))
+}
+
 pub fn help() -> String {
     format!(
-        "riff {}\nMusic as code, from the terminal.\n\nUSAGE:\n  riff <COMMAND>\n\nCOMMANDS:\n  doctor           Check the local Riff environment\n  validate <file>  Validate a .riff playlist\n  inspect <file>   Parse and print a .riff playlist\n  help             Print this help\n  version          Print version",
+        "riff {}\nMusic as code, from the terminal.\n\nUSAGE:\n  riff <COMMAND>\n\nCOMMANDS:\n  init [file]      Create a starter playlist (default: playlist.riff)\n  doctor           Check the local Riff environment\n  validate <file>  Validate a .riff playlist\n  inspect <file>   Parse and print a .riff playlist\n  help             Print this help\n  version          Print version",
         env!("CARGO_PKG_VERSION")
     )
 }
 
 fn doctor() -> String {
     format!(
-        "Riff doctor\n  version      {}\n  rust target  {}\n  playlist DSL ready\n  spotify      not configured yet\n  playback     not implemented yet",
+        "Riff doctor\n  version      {}\n  platform     {}-{}\n  playlist DSL ready\n  spotify      not configured yet\n  playback     not implemented yet",
         env!("CARGO_PKG_VERSION"),
+        std::env::consts::OS,
         std::env::consts::ARCH
     )
 }
@@ -179,5 +235,32 @@ mod tests {
     fn rejects_unknown_statement() {
         let source = "playlist \"x\" {\nshuffle true\n}";
         assert!(Playlist::parse(source).is_err());
+    }
+
+    #[test]
+    fn rejects_unquoted_playlist_name() {
+        let source = "playlist coding {\n}";
+        assert!(Playlist::parse(source).is_err());
+    }
+
+    #[test]
+    fn rejects_unquoted_track() {
+        let source = "playlist \"coding\" {\ntrack Black Sabbath - War Pigs\n}";
+        assert!(Playlist::parse(source).is_err());
+    }
+
+    #[test]
+    fn rejects_content_after_playlist() {
+        let source = "playlist \"coding\" {\n}\ntrack \"orphan\"";
+        assert!(Playlist::parse(source).is_err());
+    }
+
+    #[test]
+    fn init_defaults_to_playlist_riff() {
+        let args = vec!["init".to_string()];
+        assert_eq!(
+            Command::parse(&args).expect("command should parse"),
+            Command::Init(PathBuf::from("playlist.riff"))
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ impl Playlist {
         let mut tracks = Vec::new();
         let mut closed = false;
 
-        for line in lines {
+        for line in lines.by_ref() {
             if line == "}" {
                 closed = true;
                 break;


### PR DESCRIPTION
## Summary

Polishes the first-run experience so Riff can be installed from GitHub and used immediately for `.riff` playlist files.

### CLI
- adds `riff init [file]`
- creates a starter playlist without overwriting existing files
- improves `riff doctor` platform output
- improves empty playlist inspection

### Parser hardening
- requires quoted playlist names
- requires quoted track values
- rejects content after the closing playlist block
- adds tests for malformed input and init defaults

### Installation
- adds `INSTALL.md` with Cargo, Fish, update, uninstall and build-from-source instructions
- adds `rust-toolchain.toml`
- tunes release builds with stripping, thin LTO and a single codegen unit

This keeps the project intentionally dependency-free while making the current DSL tooling pleasant enough to install and use before Spotify playback lands.