### PR TITLE
chore: harden repository workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Nicolas25vlad

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## What changed?
+
+<!-- Describe the change and why it belongs in Riff. -->
+
+## Checklist
+
+- [ ] I ran `cargo fmt --all -- --check`
+- [ ] I ran `cargo clippy --all-targets --all-features -- -D warnings`
+- [ ] I ran `cargo test --all-features`
+- [ ] I ran `cargo check --all-targets --all-features`
+- [ ] I added or updated tests when behavior changed
+- [ ] I updated documentation when user-facing behavior changed
+
+## Notes
+
+<!-- Screenshots, terminal output, design tradeoffs, follow-up work, etc. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing to Riff
+
+Thanks for helping shape Riff while it is still young.
+
+## Before coding
+
+For parser changes, playback architecture, provider abstractions, or large UI decisions, open an issue first so behavior can be discussed before code locks in an interface.
+
+Small fixes, tests, documentation improvements, and focused refactors can go straight to a pull request.
+
+## Development setup
+
+```bash
+git clone https://github.com/Nicolas25vlad/riff.git
+cd riff
+cargo run -- doctor
+```
+
+Create a focused branch:
+
+```bash
+git checkout -b feat/my-change
+```
+
+Before opening a PR, run:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-features
+cargo check --all-targets --all-features
+```
+
+## Pull requests
+
+Keep PRs small enough to review comfortably. Explain the behavior change, not just the files changed.
+
+When behavior changes, add tests. When user-facing commands or syntax change, update the docs in the same PR.
+
+Prefer conventional, focused commit messages such as:
+
+```text
+feat: add playlist imports
+fix: reject malformed track statements
+docs: clarify cargo installation
+chore: update CI cache action
+```
+
+## Design principles
+
+Riff favors simple interfaces, fast startup, deterministic behavior, readable text formats, and provider isolation. Avoid adding abstractions before they solve a concrete problem.
+
+## Security
+
+Do not put Spotify credentials, session data, tokens, or other secrets in issues, commits, examples, logs, or screenshots.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+Riff is in early development and does not yet ship Spotify authentication or playback. Security-sensitive surfaces will grow as those features land.
+
+## Reporting a vulnerability
+
+Please avoid publishing credentials, tokens, session data, or exploit details in a public issue.
+
+For now, contact the repository owner through GitHub with a minimal description of the affected component and enough information to reproduce the problem safely. Public disclosure can happen after a fix is available.
+
+## Secrets
+
+Never commit Spotify credentials, access tokens, session blobs, cookies, or local authentication state. Example files and bug reports should use placeholders and redact private values.
+
+## Supported versions
+
+Until Riff has tagged stable releases, security fixes target the latest commit on `main`.


### PR DESCRIPTION
## Summary

Adds the repository-level guardrails that pair with protecting `main` through GitHub settings.

### Governance
- adds `CODEOWNERS` with the repository owner
- adds a focused pull request template
- adds `CONTRIBUTING.md`
- adds `SECURITY.md`

### Why

The goal is to make PR-based development the default path before Spotify auth/playback increases the project's security and maintenance surface.

> Note: branch protection itself must be enabled in GitHub repository settings because the connected GitHub integration does not expose a write action for branch protection/rulesets.