### PR TITLE
feat(player): bootstrap Spotify Connect playback core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Validate installer
         run: bash -n install.sh
 
+      - name: Install Linux audio dependencies
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev pkg-config
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Validate installer
-        run: bash -n install.sh
+      - name: Validate shell helpers
+        run: bash -n install.sh scripts/deps.sh
 
       - name: Install Linux audio dependencies
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev pkg-config
@@ -29,6 +29,9 @@ jobs:
 
       - name: Cache
         uses: Swatinem/rust-cache@v2
+
+      - name: Check dependency helper
+        run: bash scripts/deps.sh check
 
       - name: Check formatting
         run: cargo fmt --all -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riff"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 description = "A terminal-first music player where playlists are code."
 license = "MIT"
@@ -11,6 +11,8 @@ keywords = ["music", "spotify", "terminal", "tui", "rust"]
 categories = ["command-line-utilities", "multimedia::audio"]
 
 [dependencies]
+librespot = { version = "0.8.0", default-features = false, features = ["rodio-backend", "rustls-tls-native-roots"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 
 [profile.release]
 strip = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,11 @@ categories = ["command-line-utilities", "multimedia::audio"]
 librespot = { version = "0.8.0", default-features = false, features = ["rodio-backend", "rustls-tls-native-roots"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 
+# librespot 0.8.0's build script is incompatible with vergen 9.1.x.
+# Keep this exact pin until a crates.io librespot release includes upstream fix #1683.
+[build-dependencies]
+vergen = "=9.0.6"
+
 [profile.release]
 strip = true
 lto = "thin"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,7 +8,7 @@ Riff is currently distributed straight from GitHub while the project is in early
 curl -fsSL https://raw.githubusercontent.com/Nicolas25vlad/riff/main/install.sh | bash
 ```
 
-The installer checks for the basic requirements, installs Riff through Cargo, and prints the exact PATH command if `$HOME/.cargo/bin` is not available in your current shell.
+The installer checks the Rust/Git requirements and provisions the native Linux audio build dependencies on Arch/Omarchy, Debian/Ubuntu, and Fedora-family systems when they are missing.
 
 For Fish, if needed:
 
@@ -23,12 +23,32 @@ riff --version
 riff doctor
 ```
 
+## Linux audio dependencies
+
+Riff's first playback backend uses `librespot` with Rodio. On Linux this builds against ALSA.
+
+Manual packages:
+
+```bash
+# Arch / Omarchy
+sudo pacman -S --needed base-devel alsa-lib pkgconf
+
+# Debian / Ubuntu
+sudo apt-get install build-essential libasound2-dev pkg-config
+
+# Fedora
+sudo dnf install gcc make alsa-lib-devel pkgconf-pkg-config
+```
+
+The one-line installer handles these automatically when necessary.
+
 ## Install with Cargo
 
 Requirements:
 
 - Git
 - Rust stable and Cargo
+- Linux audio build dependencies listed above
 
 Install the latest `main` build:
 
@@ -48,7 +68,29 @@ For Fish:
 fish_add_path $HOME/.cargo/bin
 ```
 
-## First run
+## Start the Spotify player
+
+Spotify playback requires a Spotify Premium account because Riff uses `librespot`.
+
+Start Riff as a local Spotify Connect device:
+
+```bash
+riff player
+```
+
+On the first run, Riff opens Spotify authorization in your browser. After authentication, the session is cached under your XDG cache directory (normally `~/.cache/riff/spotify`) so you do not need to log in every time.
+
+Once the terminal prints that the player is online, select **Riff** from Spotify Connect on any Spotify client connected to your account.
+
+You can also ask Riff to load a Spotify context URI when it starts:
+
+```bash
+riff player 'spotify:album:1ATL5GLyefJaxhQzSPVrLX'
+```
+
+Press `Ctrl+C` to stop the headless player.
+
+## Playlist DSL
 
 Create a starter playlist:
 
@@ -65,15 +107,10 @@ playlist "my-playlist" {
 }
 ```
 
-Validate it:
+Validate and inspect it:
 
 ```bash
 riff validate playlist.riff
-```
-
-Inspect the parsed playlist:
-
-```bash
 riff inspect playlist.riff
 ```
 
@@ -84,6 +121,8 @@ riff init coding-metal.riff
 ```
 
 Riff refuses to overwrite an existing file.
+
+The bridge from textual `.riff` tracks to Spotify search/queue playback is the next player milestone. For now, `.riff` tooling and the Spotify Connect player are separate surfaces.
 
 ## Update
 
@@ -117,4 +156,4 @@ target/release/riff
 
 ## Current limitations
 
-The current v0.1 foundation implements the playlist DSL tooling only. Spotify authentication, `librespot` playback, the Ratatui interface, album art and audio visualization are planned but are not implemented yet.
+The v0.2 player foundation provides local Spotify Connect playback and the existing playlist DSL tools. Direct `.riff` resolution, queue control, the Ratatui interface, album artwork and audio-reactive visualization are tracked as subsequent milestones.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -53,7 +53,7 @@ Requirements:
 Install the latest `main` build:
 
 ```bash
-cargo install --git https://github.com/Nicolas25vlad/riff --locked
+cargo install --git https://github.com/Nicolas25vlad/riff
 ```
 
 Make sure Cargo's binary directory is on your `PATH`:
@@ -129,10 +129,12 @@ The bridge from textual `.riff` tracks to Spotify search/queue playback is the n
 Until packaged releases are available, update by reinstalling from GitHub:
 
 ```bash
-cargo install --git https://github.com/Nicolas25vlad/riff --locked --force
+cargo install --git https://github.com/Nicolas25vlad/riff --force
 ```
 
 You can also rerun the one-line installer. It uses `--force`, so an existing installation is replaced by the latest `main` build.
+
+A versioned root `Cargo.lock` and fully locked installs are tracked in issue #13. The known `librespot 0.8.0`/`vergen` resolution problem is pinned explicitly in `Cargo.toml` in the meantime.
 
 ## Uninstall
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,6 +23,34 @@ riff --version
 riff doctor
 ```
 
+## Project dependencies
+
+When working from a cloned checkout, Riff includes a small dependency helper:
+
+```bash
+bash scripts/deps.sh install
+```
+
+That installs missing native/system dependencies and runs `cargo fetch` for the Rust dependency graph.
+
+Other useful commands:
+
+```bash
+# Update Rust crates within Cargo.toml constraints
+bash scripts/deps.sh update
+
+# Validate the dependency graph and compile all targets/features
+bash scripts/deps.sh check
+
+# Install only native/system dependencies
+bash scripts/deps.sh native
+
+# Fetch only Rust crates
+bash scripts/deps.sh rust
+```
+
+`update` runs `cargo update`, so review `Cargo.lock` before committing dependency changes once the root lockfile is versioned.
+
 ## Linux audio dependencies
 
 Riff's first playback backend uses `librespot` with Rodio. On Linux this builds against ALSA.
@@ -40,7 +68,7 @@ sudo apt-get install build-essential libasound2-dev pkg-config
 sudo dnf install gcc make alsa-lib-devel pkgconf-pkg-config
 ```
 
-The one-line installer handles these automatically when necessary.
+The one-line installer and `bash scripts/deps.sh install` handle these automatically when necessary.
 
 ## Install with Cargo
 
@@ -147,6 +175,7 @@ cargo uninstall riff
 ```bash
 git clone https://github.com/Nicolas25vlad/riff.git
 cd riff
+bash scripts/deps.sh install
 cargo build --release
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,20 +26,18 @@ Then:
 
 ```bash
 riff doctor
-riff init
-riff validate playlist.riff
-riff inspect playlist.riff
+riff player
 ```
 
-> Using Fish and `riff` is not found after installation? Run `fish_add_path $HOME/.cargo/bin` once.
+The installer provisions the native audio build dependencies on supported Linux distributions when needed. If Fish cannot find the binary after installation, run `fish_add_path $HOME/.cargo/bin` once.
 
-For manual installation, updates, uninstall instructions and building from source, see [INSTALL.md](INSTALL.md).
+For manual installation, updates, distro dependencies and building from source, see [INSTALL.md](INSTALL.md).
 
 ## What is Riff?
 
-Riff is an experiment in treating your music library the way developers treat infrastructure and configuration.
+Riff treats your music library the way developers treat infrastructure and configuration.
 
-Instead of building every playlist by clicking through a GUI, you describe it in a small text format, keep it beside your dotfiles, review changes with `git diff`, share it on GitHub, and eventually let Riff resolve and play it through Spotify.
+Instead of building every playlist by clicking through a GUI, you describe it in a small text format, keep it beside your dotfiles, review changes with `git diff`, share it on GitHub, and let Riff grow into the runtime that resolves and plays those definitions.
 
 ```riff
 playlist "coding-metal" {
@@ -64,15 +62,33 @@ coding-metal
   4. Megadeth - Tornado of Souls
 ```
 
-The long-term goal is a complete terminal music experience powered by Rust, `librespot`, Ratatui and a declarative playlist engine.
+## First playback
+
+Riff now has the first headless Spotify playback core built on `librespot`.
+
+Start a local Spotify Connect device:
+
+```bash
+riff player
+```
+
+On first run, Riff opens Spotify authorization in your browser and caches the resulting session under your XDG cache directory. Once it reports that the player is online, choose **Riff** from Spotify Connect.
+
+You can also start with a Spotify context URI:
+
+```bash
+riff player 'spotify:album:1ATL5GLyefJaxhQzSPVrLX'
+```
+
+Spotify playback requires Premium. Directly resolving the textual tracks in a `.riff` file into Spotify tracks is the next provider/queue milestone, so the playlist DSL and player are still separate surfaces in this version.
 
 ## Why?
 
 - **Playlists as source code**: readable text files with deterministic ordering.
 - **Git-native music libraries**: branch, diff, review, fork and share playlists like code.
-- **Terminal-first playback**: search, queue, play, pause and navigate without leaving your shell.
-- **Native Spotify playback**: `librespot` is planned as the playback and Spotify Connect engine.
-- **Rich terminal UI**: album artwork, queue management, playback state and audio visualization.
+- **Terminal-first playback**: a headless player today, interactive TUI next.
+- **Native Spotify playback**: `librespot` provides local audio and Spotify Connect.
+- **Rich terminal UI**: album artwork, queue management, playback state and audio visualization are tracked milestones.
 - **Provider-independent core**: Spotify first, without permanently coupling the language to Spotify.
 
 ## Vision
@@ -97,7 +113,7 @@ The long-term goal is a complete terminal music experience powered by Rust, `lib
 └──────────────────────────────────────────────────────────────┘
 ```
 
-Planned audio path:
+The architecture is growing toward a decoded PCM path shared by playback and visualization:
 
 ```text
 .riff files
@@ -122,18 +138,20 @@ Planned audio path:
 
 ## Current status
 
-Riff is in **early development**. Today it includes:
+Riff is in **early development**, but it now crosses the line from DSL prototype into an actual player foundation:
 
-- a dependency-free Rust CLI core;
+- `riff player [spotify-uri]` starts a local Spotify Connect player;
+- OAuth login with cached credentials/session data;
+- local Rodio/ALSA audio output on Linux;
+- XDG-compatible Spotify cache directory;
 - `riff init [file]`;
 - `riff doctor`;
 - `riff validate <file>`;
 - `riff inspect <file>`;
-- the first `.riff` playlist parser;
-- parser tests;
+- the first `.riff` playlist parser and tests;
 - CI for installer syntax, formatting, Clippy, tests and `cargo check`.
 
-Spotify playback is not implemented yet.
+The next playback step is provider resolution: turning `track "Artist - Song"` into concrete Spotify IDs and feeding the Riff queue.
 
 ## Planned playlist language
 
@@ -169,9 +187,10 @@ Yes, the aspiration is essentially **Terraform for playlists**, with significant
 
 ## CLI
 
-Available today:
+Available in the v0.2 player foundation:
 
 ```text
+riff player [spotify-uri]
 riff init [file]
 riff doctor
 riff validate <file>
@@ -183,7 +202,7 @@ riff version
 Planned:
 
 ```text
-riff play [playlist|track]
+riff play <file.riff>
 riff pause
 riff next
 riff previous
@@ -218,7 +237,7 @@ riff/
 | Spotify playback | librespot |
 | Terminal UI | Ratatui + Crossterm |
 | Async runtime | Tokio |
-| Local state/cache | SQLite |
+| Local state/cache | XDG paths, SQLite later if needed |
 | Audio analysis | FFT over decoded PCM |
 | Cover art | Kitty graphics / Sixel / Unicode fallback |
 | Playlist language | custom parser + typed AST |
@@ -238,11 +257,11 @@ riff/
 
 ### v0.2 · Spotify core
 
-- [ ] Authentication/session management
+- [x] Authentication/session foundation
+- [x] `librespot` playback core
+- [x] Spotify Connect device mode
 - [ ] Track search and metadata resolution
-- [ ] `librespot` playback
-- [ ] Spotify Connect device mode
-- [ ] Play, pause, seek, next and previous
+- [ ] Riff-owned queue and play/pause/seek/next/previous commands
 
 ### v0.3 · Terminal player
 
@@ -270,6 +289,18 @@ riff/
 - [ ] `riff plan`
 - [ ] `riff apply`
 
+## Development roadmap
+
+The implementation is tracked as focused GitHub issues instead of one giant mega-PR:
+
+- **#5** Spotify playback core
+- **#6** Spotify metadata/provider resolution
+- **#7** Ratatui terminal interface
+- **#8** decoded-PCM visualizer pipeline
+- **#9** terminal album artwork
+- **#10** queue/autoplay and `.riff` playback integration
+- **#11** runtime configuration and audio backend selection
+
 ## Design principles
 
 1. **Terminal first, not terminal only.** The CLI stays scriptable even when the TUI becomes rich.
@@ -289,7 +320,7 @@ For security reports, see [SECURITY.md](SECURITY.md).
 
 Riff is an independent open-source project and is not affiliated with, endorsed by, or sponsored by Spotify AB. Spotify is a trademark of Spotify AB.
 
-Spotify-specific functionality may require Spotify Premium and will depend on the capabilities and compatibility of `librespot` and Spotify's services at the time of implementation.
+Spotify playback uses `librespot` and requires Spotify Premium. Compatibility depends on Spotify's services and upstream `librespot` behavior.
 
 ## License
 

--- a/install.sh
+++ b/install.sh
@@ -54,7 +54,7 @@ fi
 install_linux_audio_deps
 
 say "Installing Riff from GitHub..."
-cargo install --git "$REPO" --locked --force
+cargo install --git "$REPO" --force
 
 if ! command -v riff >/dev/null 2>&1; then
   warn "Riff was installed to $BIN_DIR, but that directory is not currently in PATH."

--- a/install.sh
+++ b/install.sh
@@ -21,6 +21,27 @@ fail() {
 command -v curl >/dev/null 2>&1 || fail "curl is required"
 command -v git >/dev/null 2>&1 || fail "git is required"
 
+install_linux_audio_deps() {
+  [ "$(uname -s)" = "Linux" ] || return 0
+
+  if command -v pkg-config >/dev/null 2>&1 && pkg-config --exists alsa; then
+    return 0
+  fi
+
+  say "Installing Linux audio build dependencies..."
+
+  if command -v pacman >/dev/null 2>&1; then
+    sudo pacman -S --needed --noconfirm base-devel alsa-lib pkgconf
+  elif command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update
+    sudo apt-get install -y build-essential libasound2-dev pkg-config
+  elif command -v dnf >/dev/null 2>&1; then
+    sudo dnf install -y gcc make alsa-lib-devel pkgconf-pkg-config
+  else
+    fail "Riff needs an ALSA development package and pkg-config to build its Linux audio backend. Install them with your distro package manager and run this installer again."
+  fi
+}
+
 if ! command -v cargo >/dev/null 2>&1; then
   if command -v rustup >/dev/null 2>&1; then
     say "Rustup found, installing the stable toolchain..."
@@ -29,6 +50,8 @@ if ! command -v cargo >/dev/null 2>&1; then
     fail "Cargo was not found. Install Rust first, then run this installer again."
   fi
 fi
+
+install_linux_audio_deps
 
 say "Installing Riff from GitHub..."
 cargo install --git "$REPO" --locked --force
@@ -49,4 +72,4 @@ else
   riff --version
 fi
 
-printf '\nTry it:\n  riff doctor\n  riff init\n  riff validate playlist.riff\n'
+printf '\nTry it:\n  riff doctor\n  riff player\n  riff init\n  riff validate playlist.riff\n'

--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -73,12 +73,12 @@ usage() {
 Riff dependency helper
 
 Usage:
-  ./scripts/deps.sh install   Install native dependencies and fetch Rust crates
-  ./scripts/deps.sh update    Update Rust dependencies within Cargo.toml constraints
-  ./scripts/deps.sh check     Validate dependency resolution and compile the project
-  ./scripts/deps.sh native    Install only native/system dependencies
-  ./scripts/deps.sh rust      Fetch only Rust dependencies
-  ./scripts/deps.sh help      Show this help
+  bash scripts/deps.sh install   Install native dependencies and fetch Rust crates
+  bash scripts/deps.sh update    Update Rust dependencies within Cargo.toml constraints
+  bash scripts/deps.sh check     Validate dependency resolution and compile the project
+  bash scripts/deps.sh native    Install only native/system dependencies
+  bash scripts/deps.sh rust      Fetch only Rust dependencies
+  bash scripts/deps.sh help      Show this help
 EOF
 }
 

--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+say() {
+  printf '\033[1;36m%s\033[0m\n' "$1"
+}
+
+warn() {
+  printf '\033[1;33m%s\033[0m\n' "$1"
+}
+
+fail() {
+  printf '\033[1;31merror:\033[0m %s\n' "$1" >&2
+  exit 1
+}
+
+install_native_deps() {
+  case "$(uname -s)" in
+    Linux)
+      if command -v pkg-config >/dev/null 2>&1 && pkg-config --exists alsa; then
+        say "Native Linux audio dependencies are already installed."
+        return 0
+      fi
+
+      say "Installing native Linux audio dependencies..."
+      if command -v pacman >/dev/null 2>&1; then
+        sudo pacman -S --needed --noconfirm base-devel alsa-lib pkgconf
+      elif command -v apt-get >/dev/null 2>&1; then
+        sudo apt-get update
+        sudo apt-get install -y build-essential libasound2-dev pkg-config
+      elif command -v dnf >/dev/null 2>&1; then
+        sudo dnf install -y gcc make alsa-lib-devel pkgconf-pkg-config
+      else
+        fail "Unsupported Linux package manager. Install an ALSA development package, pkg-config and a C toolchain manually."
+      fi
+      ;;
+    Darwin)
+      say "macOS detected. No extra native package is required by this helper right now."
+      ;;
+    *)
+      warn "Automatic native dependency installation is not supported on this OS yet."
+      ;;
+  esac
+}
+
+install_rust_deps() {
+  command -v cargo >/dev/null 2>&1 || fail "Cargo is required. Install Rust with rustup first."
+  say "Fetching Rust dependencies..."
+  cargo fetch
+  say "Dependencies are ready."
+}
+
+update_rust_deps() {
+  command -v cargo >/dev/null 2>&1 || fail "Cargo is required. Install Rust with rustup first."
+  say "Updating Rust dependencies within Cargo.toml constraints..."
+  cargo update
+  say "Dependency resolution updated. Review Cargo.lock before committing."
+}
+
+check_deps() {
+  command -v cargo >/dev/null 2>&1 || fail "Cargo is required. Install Rust with rustup first."
+  say "Checking dependency graph and project compilation..."
+  cargo tree >/dev/null
+  cargo check --all-targets --all-features
+  say "Dependency check passed."
+}
+
+usage() {
+  cat <<'EOF'
+Riff dependency helper
+
+Usage:
+  ./scripts/deps.sh install   Install native dependencies and fetch Rust crates
+  ./scripts/deps.sh update    Update Rust dependencies within Cargo.toml constraints
+  ./scripts/deps.sh check     Validate dependency resolution and compile the project
+  ./scripts/deps.sh native    Install only native/system dependencies
+  ./scripts/deps.sh rust      Fetch only Rust dependencies
+  ./scripts/deps.sh help      Show this help
+EOF
+}
+
+case "${1:-install}" in
+  install)
+    install_native_deps
+    install_rust_deps
+    ;;
+  update)
+    update_rust_deps
+    ;;
+  check)
+    check_deps
+    ;;
+  native)
+    install_native_deps
+    ;;
+  rust)
+    install_rust_deps
+    ;;
+  help|-h|--help)
+    usage
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 use std::{fmt, fs, path::PathBuf};
 
+pub mod player;
+
 const DEFAULT_PLAYLIST: &str = r#"playlist \"my-playlist\" {
     track \"Black Sabbath - War Pigs\"
     track \"Dio - Holy Diver\"
@@ -14,6 +16,7 @@ pub enum Command {
     Init(PathBuf),
     Validate(PathBuf),
     Inspect(PathBuf),
+    Player(Option<String>),
 }
 
 impl Command {
@@ -27,6 +30,8 @@ impl Command {
             [cmd, path] if cmd == "init" => Ok(Self::Init(path.into())),
             [cmd, path] if cmd == "validate" => Ok(Self::Validate(path.into())),
             [cmd, path] if cmd == "inspect" => Ok(Self::Inspect(path.into())),
+            [cmd] if cmd == "player" => Ok(Self::Player(None)),
+            [cmd, uri] if cmd == "player" => Ok(Self::Player(Some(uri.clone()))),
             _ => Err(RiffError::Usage(
                 "unknown command or invalid arguments".into(),
             )),
@@ -120,6 +125,7 @@ pub enum RiffError {
     Parse(String),
     Usage(String),
     AlreadyExists(PathBuf),
+    Player(String),
 }
 
 impl fmt::Display for RiffError {
@@ -133,6 +139,7 @@ impl fmt::Display for RiffError {
                 "{} already exists; choose another path or remove it first",
                 path.display()
             ),
+            Self::Player(msg) => write!(f, "player error: {msg}"),
         }
     }
 }
@@ -143,7 +150,7 @@ impl From<std::io::Error> for RiffError {
     }
 }
 
-pub fn run(command: Command) -> Result<String, RiffError> {
+pub async fn run(command: Command) -> Result<String, RiffError> {
     match command {
         Command::Help => Ok(help()),
         Command::Version => Ok(format!("riff {}", env!("CARGO_PKG_VERSION"))),
@@ -180,6 +187,14 @@ pub fn run(command: Command) -> Result<String, RiffError> {
                 ))
             }
         }
+        Command::Player(context_uri) => {
+            let options = player::PlayerOptions {
+                context_uri,
+                ..player::PlayerOptions::default()
+            };
+            player::run(options).await.map_err(RiffError::Player)?;
+            Ok(String::new())
+        }
     }
 }
 
@@ -199,14 +214,14 @@ fn init(path: PathBuf) -> Result<String, RiffError> {
 
 pub fn help() -> String {
     format!(
-        "riff {}\nMusic as code, from the terminal.\n\nUSAGE:\n  riff <COMMAND>\n\nCOMMANDS:\n  init [file]      Create a starter playlist (default: playlist.riff)\n  doctor           Check the local Riff environment\n  validate <file>  Validate a .riff playlist\n  inspect <file>   Parse and print a .riff playlist\n  help             Print this help\n  version          Print version",
+        "riff {}\nMusic as code, from the terminal.\n\nUSAGE:\n  riff <COMMAND>\n\nCOMMANDS:\n  init [file]       Create a starter playlist (default: playlist.riff)\n  doctor            Check the local Riff environment\n  validate <file>   Validate a .riff playlist\n  inspect <file>    Parse and print a .riff playlist\n  player [uri]      Start Riff as a local Spotify Connect player\n  help              Print this help\n  version           Print version",
         env!("CARGO_PKG_VERSION")
     )
 }
 
 fn doctor() -> String {
     format!(
-        "Riff doctor\n  version      {}\n  platform     {}-{}\n  playlist DSL ready\n  spotify      not configured yet\n  playback     not implemented yet",
+        "Riff doctor\n  version      {}\n  platform     {}-{}\n  playlist DSL ready\n  spotify      player core available (Premium required)\n  playback     librespot / local audio backend",
         env!("CARGO_PKG_VERSION"),
         std::env::consts::OS,
         std::env::consts::ARCH
@@ -261,6 +276,18 @@ mod tests {
         assert_eq!(
             Command::parse(&args).expect("command should parse"),
             Command::Init(PathBuf::from("playlist.riff"))
+        );
+    }
+
+    #[test]
+    fn parses_player_with_context_uri() {
+        let args = vec![
+            "player".to_string(),
+            "spotify:album:1ATL5GLyefJaxhQzSPVrLX".to_string(),
+        ];
+        assert_eq!(
+            Command::parse(&args).expect("command should parse"),
+            Command::Player(Some("spotify:album:1ATL5GLyefJaxhQzSPVrLX".to_string()))
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,15 +2,22 @@ use std::{env, process};
 
 use riff::{Command, run};
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let args: Vec<String> = env::args().skip(1).collect();
 
-    match Command::parse(&args).and_then(run) {
-        Ok(output) => {
-            if !output.is_empty() {
-                println!("{output}");
+    match Command::parse(&args) {
+        Ok(command) => match run(command).await {
+            Ok(output) => {
+                if !output.is_empty() {
+                    println!("{output}");
+                }
             }
-        }
+            Err(err) => {
+                eprintln!("riff: {err}");
+                process::exit(1);
+            }
+        },
         Err(err) => {
             eprintln!("riff: {err}");
             process::exit(1);

--- a/src/player.rs
+++ b/src/player.rs
@@ -1,0 +1,183 @@
+use std::{env, fs, path::PathBuf};
+
+use librespot::{
+    connect::{ConnectConfig, LoadRequest, LoadRequestOptions, Spirc},
+    core::{
+        authentication::Credentials,
+        cache::Cache,
+        config::SessionConfig,
+        session::Session,
+    },
+    oauth::OAuthClientBuilder,
+    playback::{
+        audio_backend,
+        config::{AudioFormat, PlayerConfig},
+        mixer,
+        mixer::MixerConfig,
+        player::Player,
+    },
+};
+
+const OAUTH_REDIRECT_URI: &str = "http://127.0.0.1:8898/login";
+const OAUTH_SCOPES: &[&str] = &[
+    "streaming",
+    "user-read-playback-state",
+    "user-modify-playback-state",
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlayerOptions {
+    pub context_uri: Option<String>,
+    pub device_name: String,
+}
+
+impl Default for PlayerOptions {
+    fn default() -> Self {
+        Self {
+            context_uri: None,
+            device_name: "Riff".to_string(),
+        }
+    }
+}
+
+pub async fn run(options: PlayerOptions) -> Result<(), String> {
+    let cache_dir = cache_dir()?;
+    let files_dir = cache_dir.join("files");
+    fs::create_dir_all(&files_dir)
+        .map_err(|err| format!("could not create Spotify cache directory: {err}"))?;
+    secure_cache_dir(&cache_dir)?;
+
+    let session_config = SessionConfig::default();
+    let player_config = PlayerConfig::default();
+    let audio_format = AudioFormat::default();
+    let mixer_config = MixerConfig::default();
+    let connect_config = ConnectConfig {
+        name: options.device_name.clone(),
+        ..ConnectConfig::default()
+    };
+
+    let sink_builder = audio_backend::find(None)
+        .ok_or_else(|| "no supported audio backend was found".to_string())?;
+    let mixer_builder =
+        mixer::find(None).ok_or_else(|| "no supported audio mixer was found".to_string())?;
+
+    let cache = Cache::new(
+        Some(cache_dir.clone()),
+        Some(cache_dir.clone()),
+        Some(files_dir),
+        None,
+    )
+    .map_err(|err| format!("could not initialize Spotify cache: {err}"))?;
+
+    let credentials = match cache.credentials() {
+        Some(credentials) => credentials,
+        None => oauth_credentials(&session_config)?,
+    };
+
+    let session = Session::new(session_config, Some(cache));
+    let mixer = mixer_builder(mixer_config).map_err(|err| format!("could not start mixer: {err}"))?;
+    let player = Player::new(
+        player_config,
+        session.clone(),
+        mixer.get_soft_volume(),
+        move || sink_builder(None, audio_format),
+    );
+
+    let (spirc, spirc_task) = Spirc::new(
+        connect_config,
+        session.clone(),
+        credentials,
+        player,
+        mixer,
+    )
+    .await
+    .map_err(|err| format!("could not start Spotify Connect: {err}"))?;
+
+    spirc
+        .activate()
+        .map_err(|err| format!("could not activate Spotify Connect device: {err}"))?;
+
+    if let Some(uri) = options.context_uri {
+        spirc
+            .load(LoadRequest::from_context_uri(
+                uri,
+                LoadRequestOptions::default(),
+            ))
+            .map_err(|err| format!("could not load Spotify URI: {err}"))?;
+        spirc
+            .play()
+            .map_err(|err| format!("could not start playback: {err}"))?;
+    }
+
+    println!("Riff player is online as `{}`.", options.device_name);
+    println!("Select it from Spotify Connect, or press Ctrl+C to stop.");
+
+    tokio::select! {
+        _ = spirc_task => Ok(()),
+        result = tokio::signal::ctrl_c() => {
+            result.map_err(|err| format!("could not listen for Ctrl+C: {err}"))?;
+            session.shutdown();
+            Ok(())
+        }
+    }
+}
+
+fn oauth_credentials(session_config: &SessionConfig) -> Result<Credentials, String> {
+    println!("No cached Spotify login found. Opening Spotify authorization in your browser...");
+
+    OAuthClientBuilder::new(
+        &session_config.client_id,
+        OAUTH_REDIRECT_URI,
+        OAUTH_SCOPES.to_vec(),
+    )
+    .open_in_browser()
+    .with_custom_message("Riff is connected. You can close this tab and return to the terminal.")
+    .build()
+    .map_err(|err| format!("could not initialize Spotify OAuth: {err}"))?
+    .get_access_token()
+    .map(|token| Credentials::with_access_token(token.access_token))
+    .map_err(|err| format!("Spotify authorization failed: {err}"))
+}
+
+fn cache_dir() -> Result<PathBuf, String> {
+    if let Some(path) = env::var_os("XDG_CACHE_HOME") {
+        return Ok(PathBuf::from(path).join("riff").join("spotify"));
+    }
+
+    let home = env::var_os("HOME").ok_or_else(|| {
+        "HOME is not set; set HOME or XDG_CACHE_HOME so Riff can store Spotify credentials"
+            .to_string()
+    })?;
+
+    Ok(PathBuf::from(home)
+        .join(".cache")
+        .join("riff")
+        .join("spotify"))
+}
+
+#[cfg(unix)]
+fn secure_cache_dir(path: &std::path::Path) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut permissions = fs::metadata(path)
+        .map_err(|err| format!("could not inspect Spotify cache permissions: {err}"))?
+        .permissions();
+    permissions.set_mode(0o700);
+    fs::set_permissions(path, permissions)
+        .map_err(|err| format!("could not secure Spotify cache directory: {err}"))
+}
+
+#[cfg(not(unix))]
+fn secure_cache_dir(_path: &std::path::Path) -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_device_name_is_riff() {
+        assert_eq!(PlayerOptions::default().device_name, "Riff");
+    }
+}

--- a/src/player.rs
+++ b/src/player.rs
@@ -2,12 +2,7 @@ use std::{env, fs, path::PathBuf};
 
 use librespot::{
     connect::{ConnectConfig, LoadRequest, LoadRequestOptions, Spirc},
-    core::{
-        authentication::Credentials,
-        cache::Cache,
-        config::SessionConfig,
-        session::Session,
-    },
+    core::{authentication::Credentials, cache::Cache, config::SessionConfig, session::Session},
     oauth::OAuthClientBuilder,
     playback::{
         audio_backend,
@@ -75,7 +70,8 @@ pub async fn run(options: PlayerOptions) -> Result<(), String> {
     };
 
     let session = Session::new(session_config, Some(cache));
-    let mixer = mixer_builder(mixer_config).map_err(|err| format!("could not start mixer: {err}"))?;
+    let mixer =
+        mixer_builder(mixer_config).map_err(|err| format!("could not start mixer: {err}"))?;
     let player = Player::new(
         player_config,
         session.clone(),
@@ -83,15 +79,10 @@ pub async fn run(options: PlayerOptions) -> Result<(), String> {
         move || sink_builder(None, audio_format),
     );
 
-    let (spirc, spirc_task) = Spirc::new(
-        connect_config,
-        session.clone(),
-        credentials,
-        player,
-        mixer,
-    )
-    .await
-    .map_err(|err| format!("could not start Spotify Connect: {err}"))?;
+    let (spirc, spirc_task) =
+        Spirc::new(connect_config, session.clone(), credentials, player, mixer)
+            .await
+            .map_err(|err| format!("could not start Spotify Connect: {err}"))?;
 
     spirc
         .activate()


### PR DESCRIPTION
## Summary

Starts implementation of #5 with the first real playback boundary for Riff.

### Player core
- integrates `librespot` 0.8.0
- adds `riff player [spotify-uri]`
- starts a local Spotify Connect device named `Riff`
- uses OAuth when no cached credentials exist
- persists Spotify credentials/cache under the user's XDG cache path
- secures the cache directory on Unix
- supports loading an optional Spotify context URI on startup
- exits cleanly on Ctrl+C

### CLI/runtime
- moves the CLI onto Tokio
- bumps the crate to v0.2.0
- updates `riff doctor` and help output

### Linux/install
- provisions ALSA build dependencies in the one-line installer on Arch/Omarchy, Debian/Ubuntu and Fedora-family systems when missing
- adds `scripts/deps.sh` for project dependency management
- `bash scripts/deps.sh install` installs native dependencies and fetches Rust crates
- `bash scripts/deps.sh update` updates crates within `Cargo.toml` constraints
- `bash scripts/deps.sh check` validates the dependency graph and builds all targets/features
- documents first playback, dependency management and Spotify Connect usage
- CI validates the helper and builds the actual Rodio/ALSA path

### Build compatibility
- pins `vergen = 9.0.6`, matching librespot upstream fix #1683 for the 0.8.0 build regression
- root `Cargo.lock` + fully locked installs are tracked separately in #13

## Verification

CI covers:
- shell helper syntax
- dependency helper check
- rustfmt
- Clippy with `-D warnings`
- tests
- `cargo check`

## Notes

This PR intentionally does not resolve text tracks from `.riff` files yet. That provider/search bridge is tracked in #6 and queue integration in #10.

Spotify Premium is required by librespot for playback.

This should receive one live smoke test on Linux with a real Spotify account/audio device before merge, because CI can compile the audio path but cannot validate account authorization or actual speaker output.

Closes part of #5.