### PR TITLE
feat(play): play .riff playlists through Spotify

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riff"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 description = "A terminal-first music player where playlists are code."
 license = "MIT"
@@ -14,6 +14,8 @@ categories = ["command-line-utilities", "multimedia::audio"]
 env_logger = "0.11"
 librespot = { version = "0.8.0", default-features = false, features = ["rodio-backend", "rustls-tls-native-roots"] }
 log = "0.4"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots"] }
+serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 
 # librespot 0.8.0's build script is incompatible with vergen 9.1.x.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,9 @@ use std::{fmt, fs, path::PathBuf};
 
 pub mod player;
 
-const DEFAULT_PLAYLIST: &str = r#"playlist \"my-playlist\" {
-    track \"Black Sabbath - War Pigs\"
-    track \"Dio - Holy Diver\"
+const DEFAULT_PLAYLIST: &str = r#"playlist "my-playlist" {
+    track "Black Sabbath - War Pigs"
+    track "Dio - Holy Diver"
 }
 "#;
 
@@ -16,6 +16,7 @@ pub enum Command {
     Init(PathBuf),
     Validate(PathBuf),
     Inspect(PathBuf),
+    Play(PathBuf),
     Player(Option<String>),
 }
 
@@ -30,6 +31,7 @@ impl Command {
             [cmd, path] if cmd == "init" => Ok(Self::Init(path.into())),
             [cmd, path] if cmd == "validate" => Ok(Self::Validate(path.into())),
             [cmd, path] if cmd == "inspect" => Ok(Self::Inspect(path.into())),
+            [cmd, path] if cmd == "play" => Ok(Self::Play(path.into())),
             [cmd] if cmd == "player" => Ok(Self::Player(None)),
             [cmd, uri] if cmd == "player" => Ok(Self::Player(Some(uri.clone()))),
             _ => Err(RiffError::Usage(
@@ -187,6 +189,27 @@ pub async fn run(command: Command) -> Result<String, RiffError> {
                 ))
             }
         }
+        Command::Play(path) => {
+            let source = fs::read_to_string(&path)?;
+            let playlist = Playlist::parse(&source)?;
+            if playlist.tracks.is_empty() {
+                return Err(RiffError::Parse("playlist has no tracks to play".into()));
+            }
+
+            println!(
+                "Loading `{}` from {} ({} tracks)...",
+                playlist.name,
+                path.display(),
+                playlist.tracks.len()
+            );
+
+            let options = player::PlayerOptions {
+                track_queries: playlist.tracks,
+                ..player::PlayerOptions::default()
+            };
+            player::run(options).await.map_err(RiffError::Player)?;
+            Ok(String::new())
+        }
         Command::Player(context_uri) => {
             let options = player::PlayerOptions {
                 context_uri,
@@ -205,7 +228,8 @@ fn init(path: PathBuf) -> Result<String, RiffError> {
 
     fs::write(&path, DEFAULT_PLAYLIST)?;
     Ok(format!(
-        "✓ created {}\n\nNext:\n  riff validate {}\n  riff inspect {}",
+        "✓ created {}\n\nNext:\n  riff validate {}\n  riff inspect {}\n  riff play {}",
+        path.display(),
         path.display(),
         path.display(),
         path.display()
@@ -214,14 +238,14 @@ fn init(path: PathBuf) -> Result<String, RiffError> {
 
 pub fn help() -> String {
     format!(
-        "riff {}\nMusic as code, from the terminal.\n\nUSAGE:\n  riff <COMMAND>\n\nCOMMANDS:\n  init [file]       Create a starter playlist (default: playlist.riff)\n  doctor            Check the local Riff environment\n  validate <file>   Validate a .riff playlist\n  inspect <file>    Parse and print a .riff playlist\n  player [uri]      Start Riff as a local Spotify Connect player\n  help              Print this help\n  version           Print version",
+        "riff {}\nMusic as code, from the terminal.\n\nUSAGE:\n  riff <COMMAND>\n\nCOMMANDS:\n  init [file]       Create a starter playlist (default: playlist.riff)\n  doctor            Check the local Riff environment\n  validate <file>   Validate a .riff playlist\n  inspect <file>    Parse and print a .riff playlist\n  play <file>       Resolve a .riff playlist on Spotify and start playback\n  player [uri]      Start Riff as a local Spotify Connect player\n  help              Print this help\n  version           Print version",
         env!("CARGO_PKG_VERSION")
     )
 }
 
 fn doctor() -> String {
     format!(
-        "Riff doctor\n  version      {}\n  platform     {}-{}\n  playlist DSL ready\n  spotify      player core available (Premium required)\n  playback     librespot / local audio backend",
+        "Riff doctor\n  version      {}\n  platform     {}-{}\n  playlist DSL ready\n  spotify      player + .riff resolution available (Premium required)\n  playback     librespot / local audio backend",
         env!("CARGO_PKG_VERSION"),
         std::env::consts::OS,
         std::env::consts::ARCH
@@ -243,6 +267,13 @@ mod tests {
 
         let playlist = Playlist::parse(source).expect("playlist should parse");
         assert_eq!(playlist.name, "coding-metal");
+        assert_eq!(playlist.tracks.len(), 2);
+    }
+
+    #[test]
+    fn default_playlist_template_is_valid() {
+        let playlist = Playlist::parse(DEFAULT_PLAYLIST).expect("default template should parse");
+        assert_eq!(playlist.name, "my-playlist");
         assert_eq!(playlist.tracks.len(), 2);
     }
 
@@ -276,6 +307,15 @@ mod tests {
         assert_eq!(
             Command::parse(&args).expect("command should parse"),
             Command::Init(PathBuf::from("playlist.riff"))
+        );
+    }
+
+    #[test]
+    fn parses_play_command() {
+        let args = vec!["play".to_string(), "coding-metal.riff".to_string()];
+        assert_eq!(
+            Command::parse(&args).expect("command should parse"),
+            Command::Play(PathBuf::from("coding-metal.riff"))
         );
     }
 

--- a/src/player.rs
+++ b/src/player.rs
@@ -13,6 +13,7 @@ use librespot::{
         player::Player,
     },
 };
+use serde::Deserialize;
 
 const OAUTH_REDIRECT_URI: &str = "http://127.0.0.1:8898/login";
 const OAUTH_SCOPES: &[&str] = &[
@@ -20,10 +21,12 @@ const OAUTH_SCOPES: &[&str] = &[
     "user-read-playback-state",
     "user-modify-playback-state",
 ];
+const SEARCH_TOKEN_SCOPES: &str = "streaming";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PlayerOptions {
     pub context_uri: Option<String>,
+    pub track_queries: Vec<String>,
     pub device_name: String,
 }
 
@@ -31,6 +34,7 @@ impl Default for PlayerOptions {
     fn default() -> Self {
         Self {
             context_uri: None,
+            track_queries: Vec::new(),
             device_name: "Riff".to_string(),
         }
     }
@@ -91,10 +95,22 @@ pub async fn run(options: PlayerOptions) -> Result<(), String> {
         .activate()
         .map_err(|err| format!("could not activate Spotify Connect device: {err}"))?;
 
-    if let Some(uri) = options.context_uri {
+    if !options.track_queries.is_empty() {
+        let resolved = resolve_track_queries(&session, &options.track_queries).await?;
+        println!("Resolved {} track(s). Starting playlist...", resolved.len());
+        spirc
+            .load(LoadRequest::from_tracks(
+                resolved.into_iter().map(|track| track.uri).collect(),
+                LoadRequestOptions::default(),
+            ))
+            .map_err(|err| format!("could not load resolved playlist: {err}"))?;
+        spirc
+            .play()
+            .map_err(|err| format!("could not start playlist playback: {err}"))?;
+    } else if let Some(uri) = options.context_uri.as_ref() {
         spirc
             .load(LoadRequest::from_context_uri(
-                uri,
+                uri.clone(),
                 LoadRequestOptions::default(),
             ))
             .map_err(|err| format!("could not load Spotify URI: {err}"))?;
@@ -104,7 +120,9 @@ pub async fn run(options: PlayerOptions) -> Result<(), String> {
     }
 
     println!("Riff player is online as `{}`.", options.device_name);
-    println!("Select it from Spotify Connect and press play in Spotify.");
+    if options.track_queries.is_empty() && options.context_uri.is_none() {
+        println!("Select it from Spotify Connect and press play in Spotify.");
+    }
     println!("Playback diagnostics are enabled. For full logs: RIFF_LOG=debug riff player");
     println!("Press Ctrl+C to stop.");
 
@@ -117,6 +135,100 @@ pub async fn run(options: PlayerOptions) -> Result<(), String> {
             session.shutdown();
             Ok(())
         }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ResolvedTrack {
+    uri: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct SearchResponse {
+    tracks: SearchTracks,
+}
+
+#[derive(Debug, Deserialize)]
+struct SearchTracks {
+    items: Vec<SearchTrack>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SearchTrack {
+    uri: String,
+    name: String,
+    artists: Vec<SearchArtist>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SearchArtist {
+    name: String,
+}
+
+async fn resolve_track_queries(
+    session: &Session,
+    queries: &[String],
+) -> Result<Vec<ResolvedTrack>, String> {
+    let token = session
+        .token_provider()
+        .get_token(SEARCH_TOKEN_SCOPES)
+        .await
+        .map_err(|err| format!("could not obtain Spotify search token: {err}"))?;
+
+    let client = reqwest::Client::new();
+    let mut resolved = Vec::with_capacity(queries.len());
+
+    for (index, query) in queries.iter().enumerate() {
+        println!("  [{}/{}] resolving {query}", index + 1, queries.len());
+
+        let response = client
+            .get("https://api.spotify.com/v1/search")
+            .bearer_auth(&token.access_token)
+            .query(&[("q", query.as_str()), ("type", "track"), ("limit", "5")])
+            .send()
+            .await
+            .map_err(|err| format!("Spotify search failed for `{query}`: {err}"))?
+            .error_for_status()
+            .map_err(|err| format!("Spotify rejected search for `{query}`: {err}"))?
+            .json::<SearchResponse>()
+            .await
+            .map_err(|err| format!("could not decode Spotify search for `{query}`: {err}"))?;
+
+        let track = choose_track(query, response.tracks.items)
+            .ok_or_else(|| format!("no Spotify track found for `{query}`"))?;
+        let artists = track
+            .artists
+            .iter()
+            .map(|artist| artist.name.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        println!("       -> {artists} - {}", track.name);
+        resolved.push(ResolvedTrack { uri: track.uri });
+    }
+
+    Ok(resolved)
+}
+
+fn choose_track(query: &str, tracks: Vec<SearchTrack>) -> Option<SearchTrack> {
+    let (expected_artist, expected_title) = query
+        .split_once(" - ")
+        .map(|(artist, title)| (Some(artist.trim()), title.trim()))
+        .unwrap_or((None, query.trim()));
+
+    let exact_index = tracks.iter().position(|track| {
+        track.name.eq_ignore_ascii_case(expected_title)
+            && expected_artist.is_none_or(|artist| {
+                track
+                    .artists
+                    .iter()
+                    .any(|candidate| candidate.name.eq_ignore_ascii_case(artist))
+            })
+    });
+
+    match exact_index {
+        Some(index) => tracks.into_iter().nth(index),
+        None => tracks.into_iter().next(),
     }
 }
 
@@ -179,8 +291,36 @@ fn secure_cache_dir(_path: &std::path::Path) -> Result<(), String> {
 mod tests {
     use super::*;
 
+    fn track(uri: &str, name: &str, artist: &str) -> SearchTrack {
+        SearchTrack {
+            uri: uri.to_string(),
+            name: name.to_string(),
+            artists: vec![SearchArtist {
+                name: artist.to_string(),
+            }],
+        }
+    }
+
     #[test]
     fn default_device_name_is_riff() {
         assert_eq!(PlayerOptions::default().device_name, "Riff");
+    }
+
+    #[test]
+    fn chooses_exact_artist_and_title_when_available() {
+        let tracks = vec![
+            track("spotify:track:wrong", "War Pigs", "Cover Band"),
+            track("spotify:track:right", "War Pigs", "Black Sabbath"),
+        ];
+
+        let selected = choose_track("Black Sabbath - War Pigs", tracks).expect("track expected");
+        assert_eq!(selected.uri, "spotify:track:right");
+    }
+
+    #[test]
+    fn falls_back_to_first_search_result() {
+        let tracks = vec![track("spotify:track:first", "Other Name", "Other Artist")];
+        let selected = choose_track("Unknown - Query", tracks).expect("track expected");
+        assert_eq!(selected.uri, "spotify:track:first");
     }
 }


### PR DESCRIPTION
## Summary

Implements the first end-to-end `.riff` playback path.

### CLI
- adds `riff play <file.riff>`
- parses and validates the playlist before starting playback
- rejects empty playlists
- updates help/doctor output

### Spotify resolution
- obtains a Spotify bearer token from the authenticated librespot session
- resolves each `track "Artist - Title"` with Spotify search
- prefers an exact case-insensitive artist + title match when available
- prints the resolved result for every track
- falls back to the first Spotify search result when there is no exact match

### Playback
- converts resolved tracks to Spotify URIs
- loads the whole sequence with `LoadRequest::from_tracks(...)`
- starts playback automatically

### Reliability
- fixes the starter `riff init` template, which was incorrectly writing literal escaped quotes from a raw Rust string
- adds regression coverage for the starter template and `riff play` command
- includes the diagnostics changes that are now on `main`

## Usage

```bash
riff play coding-metal.riff
```

## Notes

Spotify Premium is still required by librespot. Track-name resolution uses the authenticated Spotify session, so no separate client secret is required.

Tracks are resolved sequentially for now. Caching/parallel resolution can be added later if large playlists make this slow.

Progresses #6 and #10.