### PR TITLE
feat: add deterministic track IDs and CLI discovery

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riff"
-version = "0.2.4"
+version = "0.3.0"
 edition = "2024"
 description = "A terminal-first music player where playlists are code."
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,9 @@ impl Playlist {
 fn parse_track(value: &str) -> Result<Track, RiffError> {
     let value = value.trim();
     if !value.starts_with('"') {
-        return Err(RiffError::Parse("track must start with a quoted label".into()));
+        return Err(RiffError::Parse(
+            "track must start with a quoted label".into(),
+        ));
     }
 
     let closing_quote = value[1..]
@@ -348,7 +350,11 @@ fn format_candidates(query: &str, candidates: &[player::SearchCandidate]) -> Str
 }
 
 fn format_candidate_details(candidate: &player::SearchCandidate) -> String {
-    let mut lines = vec![format!("{}\nid: {}", candidate.display_name(), candidate.uri)];
+    let mut lines = vec![format!(
+        "{}\nid: {}",
+        candidate.display_name(),
+        candidate.uri
+    )];
     if candidate.metadata.is_empty() {
         lines.push("metadata: not returned by Spotify context resolver".to_string());
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{fmt, fs, path::PathBuf};
+use std::{fmt, fs, io, io::Write, path::PathBuf};
 
 pub mod player;
 
@@ -18,6 +18,9 @@ pub enum Command {
     Inspect(PathBuf),
     Play(PathBuf),
     Player(Option<String>),
+    Search { query: String, limit: usize },
+    InspectTrack(String),
+    Pick(String),
 }
 
 impl Command {
@@ -34,6 +37,26 @@ impl Command {
             [cmd, path] if cmd == "play" => Ok(Self::Play(path.into())),
             [cmd] if cmd == "player" => Ok(Self::Player(None)),
             [cmd, uri] if cmd == "player" => Ok(Self::Player(Some(uri.clone()))),
+            [cmd, query] if cmd == "search" => Ok(Self::Search {
+                query: query.clone(),
+                limit: 10,
+            }),
+            [cmd, query, flag, limit] if cmd == "search" && flag == "--limit" => {
+                let limit = limit.parse::<usize>().map_err(|_| {
+                    RiffError::Usage("search --limit must be a positive integer".into())
+                })?;
+                if limit == 0 {
+                    return Err(RiffError::Usage(
+                        "search --limit must be greater than zero".into(),
+                    ));
+                }
+                Ok(Self::Search {
+                    query: query.clone(),
+                    limit,
+                })
+            }
+            [cmd, uri] if cmd == "inspect-track" => Ok(Self::InspectTrack(uri.clone())),
+            [cmd, query] if cmd == "pick" => Ok(Self::Pick(query.clone())),
             _ => Err(RiffError::Usage(
                 "unknown command or invalid arguments".into(),
             )),
@@ -42,9 +65,15 @@ impl Command {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Track {
+    pub label: String,
+    pub id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Playlist {
     pub name: String,
-    pub tracks: Vec<String>,
+    pub tracks: Vec<Track>,
 }
 
 impl Playlist {
@@ -72,12 +101,7 @@ impl Playlist {
                 .strip_prefix("track ")
                 .ok_or_else(|| RiffError::Parse(format!("unsupported statement: `{line}`")))?;
 
-            let track = parse_quoted(value, "track")?;
-            if track.is_empty() {
-                return Err(RiffError::Parse("track cannot be empty".into()));
-            }
-
-            tracks.push(track.to_string());
+            tracks.push(parse_track(value)?);
         }
 
         if !closed {
@@ -95,6 +119,41 @@ impl Playlist {
             tracks,
         })
     }
+}
+
+fn parse_track(value: &str) -> Result<Track, RiffError> {
+    let value = value.trim();
+    if !value.starts_with('"') {
+        return Err(RiffError::Parse("track must start with a quoted label".into()));
+    }
+
+    let closing_quote = value[1..]
+        .find('"')
+        .map(|index| index + 1)
+        .ok_or_else(|| RiffError::Parse("track label is missing its closing quote".into()))?;
+    let label = &value[1..closing_quote];
+    if label.is_empty() {
+        return Err(RiffError::Parse("track cannot be empty".into()));
+    }
+
+    let rest = value[closing_quote + 1..].trim();
+    let id = if rest.is_empty() {
+        None
+    } else {
+        let raw_id = rest
+            .strip_prefix("id=")
+            .ok_or_else(|| RiffError::Parse(format!("unsupported track selector: `{rest}`")))?;
+        let id = parse_quoted(raw_id, "track id")?;
+        if id.is_empty() {
+            return Err(RiffError::Parse("track id cannot be empty".into()));
+        }
+        Some(id.to_string())
+    };
+
+    Ok(Track {
+        label: label.to_string(),
+        id,
+    })
 }
 
 fn parse_playlist_header(header: &str) -> Result<&str, RiffError> {
@@ -174,7 +233,10 @@ pub async fn run(command: Command) -> Result<String, RiffError> {
                 .tracks
                 .iter()
                 .enumerate()
-                .map(|(index, track)| format!("{:>3}. {track}", index + 1))
+                .map(|(index, track)| match track.id.as_deref() {
+                    Some(id) => format!("{:>3}. {}\n     id: {id}", index + 1, track.label),
+                    None => format!("{:>3}. {}", index + 1, track.label),
+                })
                 .collect::<Vec<_>>()
                 .join("\n");
 
@@ -204,7 +266,14 @@ pub async fn run(command: Command) -> Result<String, RiffError> {
             );
 
             let options = player::PlayerOptions {
-                track_queries: playlist.tracks,
+                tracks: playlist
+                    .tracks
+                    .into_iter()
+                    .map(|track| player::TrackRequest {
+                        label: track.label,
+                        id: track.id,
+                    })
+                    .collect(),
                 ..player::PlayerOptions::default()
             };
             player::run(options).await.map_err(RiffError::Player)?;
@@ -218,7 +287,81 @@ pub async fn run(command: Command) -> Result<String, RiffError> {
             player::run(options).await.map_err(RiffError::Player)?;
             Ok(String::new())
         }
+        Command::Search { query, limit } => {
+            let candidates = player::search(&query, limit)
+                .await
+                .map_err(RiffError::Player)?;
+            if candidates.is_empty() {
+                return Ok(format!("No Spotify tracks found for `{query}`."));
+            }
+            Ok(format_candidates(&query, &candidates))
+        }
+        Command::InspectTrack(uri) => {
+            let candidate = player::inspect_track(&uri)
+                .await
+                .map_err(RiffError::Player)?;
+            Ok(format_candidate_details(&candidate))
+        }
+        Command::Pick(query) => {
+            let candidates = player::search(&query, 10)
+                .await
+                .map_err(RiffError::Player)?;
+            if candidates.is_empty() {
+                return Ok(format!("No Spotify tracks found for `{query}`."));
+            }
+
+            println!("{}", format_candidates(&query, &candidates));
+            print!("\nChoose a recording [1-{}]: ", candidates.len());
+            io::stdout().flush()?;
+            let mut input = String::new();
+            io::stdin().read_line(&mut input)?;
+            let selection = input
+                .trim()
+                .parse::<usize>()
+                .ok()
+                .filter(|value| (1..=candidates.len()).contains(value))
+                .ok_or_else(|| RiffError::Usage("invalid recording selection".into()))?;
+            let candidate = &candidates[selection - 1];
+            Ok(format!(
+                "track \"{}\" id=\"{}\"",
+                escape_riff_string(&query),
+                candidate.uri
+            ))
+        }
     }
+}
+
+fn format_candidates(query: &str, candidates: &[player::SearchCandidate]) -> String {
+    let mut lines = vec![format!("Spotify recordings for `{query}`:")];
+    for (index, candidate) in candidates.iter().enumerate() {
+        lines.push(format!(
+            "\n{}. {}\n   id: {}",
+            index + 1,
+            candidate.display_name(),
+            candidate.uri
+        ));
+        for (key, value) in candidate.metadata.iter().take(6) {
+            lines.push(format!("   {key}: {value}"));
+        }
+    }
+    lines.join("\n")
+}
+
+fn format_candidate_details(candidate: &player::SearchCandidate) -> String {
+    let mut lines = vec![format!("{}\nid: {}", candidate.display_name(), candidate.uri)];
+    if candidate.metadata.is_empty() {
+        lines.push("metadata: not returned by Spotify context resolver".to_string());
+    } else {
+        lines.push("metadata:".to_string());
+        for (key, value) in &candidate.metadata {
+            lines.push(format!("  {key}: {value}"));
+        }
+    }
+    lines.join("\n")
+}
+
+fn escape_riff_string(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
 fn init(path: PathBuf) -> Result<String, RiffError> {
@@ -238,14 +381,14 @@ fn init(path: PathBuf) -> Result<String, RiffError> {
 
 pub fn help() -> String {
     format!(
-        "riff {}\nMusic as code, from the terminal.\n\nUSAGE:\n  riff <COMMAND>\n\nCOMMANDS:\n  init [file]       Create a starter playlist (default: playlist.riff)\n  doctor            Check the local Riff environment\n  validate <file>   Validate a .riff playlist\n  inspect <file>    Parse and print a .riff playlist\n  play <file>       Resolve a .riff playlist on Spotify and start playback\n  player [uri]      Start Riff as a local Spotify Connect player\n  help              Print this help\n  version           Print version",
+        "riff {}\nMusic as code, from the terminal.\n\nUSAGE:\n  riff <COMMAND>\n\nCOMMANDS:\n  init [file]         Create a starter playlist (default: playlist.riff)\n  doctor              Check the local Riff environment\n  validate <file>     Validate a .riff playlist\n  inspect <file>      Parse and print a .riff playlist\n  play <file>         Resolve a .riff playlist on Spotify and start playback\n  search <query>      Explore Spotify recordings and stable track IDs\n  inspect-track <id>  Inspect one Spotify track ID\n  pick <query>        Interactively choose a recording and print pinned DSL\n  player [uri]        Start Riff as a local Spotify Connect player\n  help                Print this help\n  version             Print version",
         env!("CARGO_PKG_VERSION")
     )
 }
 
 fn doctor() -> String {
     format!(
-        "Riff doctor\n  version      {}\n  platform     {}-{}\n  playlist DSL ready\n  spotify      player + .riff resolution available (Premium required)\n  playback     librespot / local audio backend",
+        "Riff doctor\n  version      {}\n  platform     {}-{}\n  playlist DSL ready\n  spotify      player + discovery + pinned track ids available (Premium required)\n  playback     librespot / local audio backend",
         env!("CARGO_PKG_VERSION"),
         std::env::consts::OS,
         std::env::consts::ARCH
@@ -268,6 +411,25 @@ mod tests {
         let playlist = Playlist::parse(source).expect("playlist should parse");
         assert_eq!(playlist.name, "coding-metal");
         assert_eq!(playlist.tracks.len(), 2);
+        assert_eq!(playlist.tracks[0].label, "Black Sabbath - War Pigs");
+        assert_eq!(playlist.tracks[0].id, None);
+    }
+
+    #[test]
+    fn parses_pinned_track_id() {
+        let source = r#"
+            playlist "coding-metal" {
+                track "Black Sabbath - War Pigs" id="spotify:track:abc123"
+            }
+        "#;
+        let playlist = Playlist::parse(source).expect("playlist should parse");
+        assert_eq!(
+            playlist.tracks[0],
+            Track {
+                label: "Black Sabbath - War Pigs".to_string(),
+                id: Some("spotify:track:abc123".to_string())
+            }
+        );
     }
 
     #[test]
@@ -316,6 +478,23 @@ mod tests {
         assert_eq!(
             Command::parse(&args).expect("command should parse"),
             Command::Play(PathBuf::from("coding-metal.riff"))
+        );
+    }
+
+    #[test]
+    fn parses_search_limit() {
+        let args = vec![
+            "search".to_string(),
+            "War Pigs".to_string(),
+            "--limit".to_string(),
+            "20".to_string(),
+        ];
+        assert_eq!(
+            Command::parse(&args).expect("command should parse"),
+            Command::Search {
+                query: "War Pigs".to_string(),
+                limit: 20
+            }
         );
     }
 

--- a/src/player.rs
+++ b/src/player.rs
@@ -1,4 +1,4 @@
-use std::{env, fs, path::PathBuf};
+use std::{collections::BTreeMap, env, fs, path::PathBuf};
 
 use env_logger::Env;
 use librespot::{
@@ -22,9 +22,32 @@ const OAUTH_SCOPES: &[&str] = &[
 ];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrackRequest {
+    pub label: String,
+    pub id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SearchCandidate {
+    pub uri: String,
+    pub metadata: BTreeMap<String, String>,
+}
+
+impl SearchCandidate {
+    pub fn display_name(&self) -> String {
+        for key in ["title", "name", "track_name"] {
+            if let Some(value) = self.metadata.get(key) {
+                return value.clone();
+            }
+        }
+        self.uri.clone()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PlayerOptions {
     pub context_uri: Option<String>,
-    pub track_queries: Vec<String>,
+    pub tracks: Vec<TrackRequest>,
     pub device_name: String,
 }
 
@@ -32,7 +55,7 @@ impl Default for PlayerOptions {
     fn default() -> Self {
         Self {
             context_uri: None,
-            track_queries: Vec::new(),
+            tracks: Vec::new(),
             device_name: "Riff".to_string(),
         }
     }
@@ -41,13 +64,7 @@ impl Default for PlayerOptions {
 pub async fn run(options: PlayerOptions) -> Result<(), String> {
     init_logging();
 
-    let cache_dir = cache_dir()?;
-    let files_dir = cache_dir.join("files");
-    fs::create_dir_all(&files_dir)
-        .map_err(|err| format!("could not create Spotify cache directory: {err}"))?;
-    secure_cache_dir(&cache_dir)?;
-
-    let session_config = SessionConfig::default();
+    let (session_config, cache, credentials) = session_parts()?;
     let player_config = PlayerConfig::default();
     let audio_format = AudioFormat::default();
     let mixer_config = MixerConfig::default();
@@ -60,19 +77,6 @@ pub async fn run(options: PlayerOptions) -> Result<(), String> {
         .ok_or_else(|| "no supported audio backend was found".to_string())?;
     let mixer_builder =
         mixer::find(None).ok_or_else(|| "no supported audio mixer was found".to_string())?;
-
-    let cache = Cache::new(
-        Some(cache_dir.clone()),
-        Some(cache_dir.clone()),
-        Some(files_dir),
-        None,
-    )
-    .map_err(|err| format!("could not initialize Spotify cache: {err}"))?;
-
-    let credentials = match cache.credentials() {
-        Some(credentials) => credentials,
-        None => oauth_credentials(&session_config)?,
-    };
 
     let session = Session::new(session_config, Some(cache));
     let mixer =
@@ -93,12 +97,12 @@ pub async fn run(options: PlayerOptions) -> Result<(), String> {
         .activate()
         .map_err(|err| format!("could not activate Spotify Connect device: {err}"))?;
 
-    if !options.track_queries.is_empty() {
-        let resolved = resolve_track_queries(&session, &options.track_queries).await?;
+    if !options.tracks.is_empty() {
+        let resolved = resolve_tracks(&session, &options.tracks).await?;
         println!("Resolved {} track(s). Starting playlist...", resolved.len());
         spirc
             .load(LoadRequest::from_tracks(
-                resolved.into_iter().map(|track| track.uri).collect(),
+                resolved,
                 LoadRequestOptions::default(),
             ))
             .map_err(|err| format!("could not load resolved playlist: {err}"))?;
@@ -118,7 +122,7 @@ pub async fn run(options: PlayerOptions) -> Result<(), String> {
     }
 
     println!("Riff player is online as `{}`.", options.device_name);
-    if options.track_queries.is_empty() && options.context_uri.is_none() {
+    if options.tracks.is_empty() && options.context_uri.is_none() {
         println!("Select it from Spotify Connect and press play in Spotify.");
     }
     println!("Playback diagnostics are enabled. For full logs: RIFF_LOG=debug riff player");
@@ -136,40 +140,142 @@ pub async fn run(options: PlayerOptions) -> Result<(), String> {
     }
 }
 
-#[derive(Debug, Clone)]
-struct ResolvedTrack {
-    uri: String,
+pub async fn search(query: &str, limit: usize) -> Result<Vec<SearchCandidate>, String> {
+    init_logging();
+    let session = discovery_session().await?;
+    let result = search_with_session(&session, query, limit).await;
+    session.shutdown();
+    result
 }
 
-async fn resolve_track_queries(
-    session: &Session,
-    queries: &[String],
-) -> Result<Vec<ResolvedTrack>, String> {
-    let mut resolved = Vec::with_capacity(queries.len());
+pub async fn inspect_track(uri: &str) -> Result<SearchCandidate, String> {
+    if !is_spotify_track_uri(uri) {
+        return Err("track id must look like `spotify:track:<id>`".to_string());
+    }
 
-    for (index, query) in queries.iter().enumerate() {
-        println!("  [{}/{}] resolving {query}", index + 1, queries.len());
+    init_logging();
+    let session = discovery_session().await?;
+    let context = session
+        .spclient()
+        .get_context(uri)
+        .await
+        .map_err(|err| format!("could not inspect `{uri}`: {err}"))?;
 
-        let search_uri = spotify_search_uri(query);
-        let context = session
-            .spclient()
-            .get_context(&search_uri)
-            .await
-            .map_err(|err| format!("Spotify internal search failed for `{query}`: {err}"))?;
+    let candidate = candidates_from_context(context)
+        .into_iter()
+        .find(|candidate| candidate.uri == uri)
+        .or_else(|| {
+            Some(SearchCandidate {
+                uri: uri.to_string(),
+                metadata: BTreeMap::new(),
+            })
+        })
+        .ok_or_else(|| format!("Spotify did not return metadata for `{uri}`"))?;
 
-        let uri = context
-            .pages
+    session.shutdown();
+    Ok(candidate)
+}
+
+async fn resolve_tracks(session: &Session, tracks: &[TrackRequest]) -> Result<Vec<String>, String> {
+    let mut resolved = Vec::with_capacity(tracks.len());
+
+    for (index, track) in tracks.iter().enumerate() {
+        if let Some(uri) = track.id.as_deref() {
+            if !is_spotify_track_uri(uri) {
+                return Err(format!(
+                    "invalid pinned id for `{}`: expected `spotify:track:<id>`, got `{uri}`",
+                    track.label
+                ));
+            }
+            println!("  [{}/{}] pinned {}", index + 1, tracks.len(), track.label);
+            println!("       -> {uri}");
+            resolved.push(uri.to_string());
+            continue;
+        }
+
+        println!("  [{}/{}] resolving {}", index + 1, tracks.len(), track.label);
+        let candidates = search_with_session(session, &track.label, 1).await?;
+        let candidate = candidates
             .into_iter()
-            .flat_map(|page| page.tracks)
-            .filter_map(|track| track.uri)
-            .find(|uri| uri.starts_with("spotify:track:"))
-            .ok_or_else(|| format!("no Spotify track found for `{query}`"))?;
-
-        println!("       -> {uri}");
-        resolved.push(ResolvedTrack { uri });
+            .next()
+            .ok_or_else(|| format!("no Spotify track found for `{}`", track.label))?;
+        println!("       -> {}", candidate.uri);
+        resolved.push(candidate.uri);
     }
 
     Ok(resolved)
+}
+
+async fn discovery_session() -> Result<Session, String> {
+    let (session_config, cache, credentials) = session_parts()?;
+    let session = Session::new(session_config, Some(cache));
+    session
+        .connect(credentials, false)
+        .await
+        .map_err(|err| format!("could not connect to Spotify: {err}"))?;
+    Ok(session)
+}
+
+fn session_parts() -> Result<(SessionConfig, Cache, Credentials), String> {
+    let cache_dir = cache_dir()?;
+    let files_dir = cache_dir.join("files");
+    fs::create_dir_all(&files_dir)
+        .map_err(|err| format!("could not create Spotify cache directory: {err}"))?;
+    secure_cache_dir(&cache_dir)?;
+
+    let session_config = SessionConfig::default();
+    let cache = Cache::new(
+        Some(cache_dir.clone()),
+        Some(cache_dir),
+        Some(files_dir),
+        None,
+    )
+    .map_err(|err| format!("could not initialize Spotify cache: {err}"))?;
+
+    let credentials = match cache.credentials() {
+        Some(credentials) => credentials,
+        None => oauth_credentials(&session_config)?,
+    };
+
+    Ok((session_config, cache, credentials))
+}
+
+async fn search_with_session(
+    session: &Session,
+    query: &str,
+    limit: usize,
+) -> Result<Vec<SearchCandidate>, String> {
+    let search_uri = spotify_search_uri(query);
+    let context = session
+        .spclient()
+        .get_context(&search_uri)
+        .await
+        .map_err(|err| format!("Spotify internal search failed for `{query}`: {err}"))?;
+
+    Ok(candidates_from_context(context)
+        .into_iter()
+        .take(limit)
+        .collect())
+}
+
+fn candidates_from_context(context: librespot::core::protocol::context::Context) -> Vec<SearchCandidate> {
+    context
+        .pages
+        .into_iter()
+        .flat_map(|page| page.tracks)
+        .filter_map(|track| {
+            let uri = track.uri?;
+            if !is_spotify_track_uri(&uri) {
+                return None;
+            }
+            let metadata = track.metadata.into_iter().collect::<BTreeMap<_, _>>();
+            Some(SearchCandidate { uri, metadata })
+        })
+        .collect()
+}
+
+fn is_spotify_track_uri(uri: &str) -> bool {
+    uri.starts_with("spotify:track:") && uri.len() > "spotify:track:".len()
 }
 
 fn spotify_search_uri(query: &str) -> String {
@@ -271,5 +377,12 @@ mod tests {
             spotify_search_uri("Motörhead"),
             "spotify:search:Mot%C3%B6rhead"
         );
+    }
+
+    #[test]
+    fn validates_spotify_track_ids() {
+        assert!(is_spotify_track_uri("spotify:track:abc123"));
+        assert!(!is_spotify_track_uri("spotify:album:abc123"));
+        assert!(!is_spotify_track_uri("spotify:track:"));
     }
 }

--- a/src/player.rs
+++ b/src/player.rs
@@ -161,19 +161,25 @@ pub async fn inspect_track(uri: &str) -> Result<SearchCandidate, String> {
         .await
         .map_err(|err| format!("could not inspect `{uri}`: {err}"))?;
 
-    let candidate = candidates_from_context(context)
-        .into_iter()
-        .find(|candidate| candidate.uri == uri)
-        .or_else(|| {
-            Some(SearchCandidate {
-                uri: uri.to_string(),
-                metadata: BTreeMap::new(),
-            })
-        })
-        .ok_or_else(|| format!("Spotify did not return metadata for `{uri}`"))?;
+    let mut candidate = None;
+    for track in context.pages.into_iter().flat_map(|page| page.tracks) {
+        let Some(track_uri) = track.uri else {
+            continue;
+        };
+        if track_uri == uri {
+            candidate = Some(SearchCandidate {
+                uri: track_uri,
+                metadata: track.metadata.into_iter().collect(),
+            });
+            break;
+        }
+    }
 
     session.shutdown();
-    Ok(candidate)
+    Ok(candidate.unwrap_or_else(|| SearchCandidate {
+        uri: uri.to_string(),
+        metadata: BTreeMap::new(),
+    }))
 }
 
 async fn resolve_tracks(session: &Session, tracks: &[TrackRequest]) -> Result<Vec<String>, String> {
@@ -252,26 +258,23 @@ async fn search_with_session(
         .await
         .map_err(|err| format!("Spotify internal search failed for `{query}`: {err}"))?;
 
-    Ok(candidates_from_context(context)
-        .into_iter()
-        .take(limit)
-        .collect())
-}
-
-fn candidates_from_context(context: librespot::core::protocol::context::Context) -> Vec<SearchCandidate> {
-    context
-        .pages
-        .into_iter()
-        .flat_map(|page| page.tracks)
-        .filter_map(|track| {
-            let uri = track.uri?;
-            if !is_spotify_track_uri(&uri) {
-                return None;
-            }
-            let metadata = track.metadata.into_iter().collect::<BTreeMap<_, _>>();
-            Some(SearchCandidate { uri, metadata })
-        })
-        .collect()
+    let mut candidates = Vec::new();
+    for track in context.pages.into_iter().flat_map(|page| page.tracks) {
+        let Some(uri) = track.uri else {
+            continue;
+        };
+        if !is_spotify_track_uri(&uri) {
+            continue;
+        }
+        candidates.push(SearchCandidate {
+            uri,
+            metadata: track.metadata.into_iter().collect(),
+        });
+        if candidates.len() == limit {
+            break;
+        }
+    }
+    Ok(candidates)
 }
 
 fn is_spotify_track_uri(uri: &str) -> bool {

--- a/src/player.rs
+++ b/src/player.rs
@@ -199,7 +199,12 @@ async fn resolve_tracks(session: &Session, tracks: &[TrackRequest]) -> Result<Ve
             continue;
         }
 
-        println!("  [{}/{}] resolving {}", index + 1, tracks.len(), track.label);
+        println!(
+            "  [{}/{}] resolving {}",
+            index + 1,
+            tracks.len(),
+            track.label
+        );
         let candidates = search_with_session(session, &track.label, 1).await?;
         let candidate = candidates
             .into_iter()


### PR DESCRIPTION
Implements the core of #18.

## What changed
- add pinned track IDs to the `.riff` DSL: `track "Artist - Song" id="spotify:track:..."`
- pinned IDs are authoritative during playback and bypass fuzzy search
- add `riff search <query> [--limit N]` to explore Spotify candidates and stable IDs
- add `riff inspect-track <spotify:track:...>` for one-ID inspection
- add `riff pick <query>` for a simple interactive chooser that prints a pinned DSL line
- preserve name-only tracks for convenient/default resolution
- expose Spotify context metadata when available
- bump version to 0.3.0

The human-readable label remains for Git diffs; the provider ID is the reproducible playback identity.