### PR TITLE
feat: add smart fuzzy search and confidence ranking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riff"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 description = "A terminal-first music player where playlists are code."
 license = "MIT"

--- a/src/fuzzy.rs
+++ b/src/fuzzy.rs
@@ -11,8 +11,16 @@ pub fn rank_candidates(
     let normalized_query = normalize(query);
 
     for candidate in &mut candidates {
-        let title = candidate.metadata.get("title").map(String::as_str).unwrap_or("");
-        let artist = candidate.metadata.get("artist").map(String::as_str).unwrap_or("");
+        let title = candidate
+            .metadata
+            .get("title")
+            .map(String::as_str)
+            .unwrap_or("");
+        let artist = candidate
+            .metadata
+            .get("artist")
+            .map(String::as_str)
+            .unwrap_or("");
         let combined = if artist.is_empty() {
             title.to_string()
         } else {
@@ -31,7 +39,9 @@ pub fn rank_candidates(
             fuzzy_score(&normalized_query, &normalize(&combined), &normalize(title))
         };
 
-        candidate.metadata.insert("match".into(), score.to_string());
+        candidate
+            .metadata
+            .insert("match".into(), score.to_string());
     }
 
     candidates.retain(|candidate| {
@@ -143,9 +153,21 @@ pub fn normalize(value: &str) -> String {
 fn version_penalty(candidate: &SearchCandidate) -> u8 {
     let haystack = format!(
         "{} {} {}",
-        candidate.metadata.get("title").map(String::as_str).unwrap_or(""),
-        candidate.metadata.get("album").map(String::as_str).unwrap_or(""),
-        candidate.metadata.get("version").map(String::as_str).unwrap_or("")
+        candidate
+            .metadata
+            .get("title")
+            .map(String::as_str)
+            .unwrap_or(""),
+        candidate
+            .metadata
+            .get("album")
+            .map(String::as_str)
+            .unwrap_or(""),
+        candidate
+            .metadata
+            .get("version")
+            .map(String::as_str)
+            .unwrap_or("")
     )
     .to_lowercase();
 

--- a/src/fuzzy.rs
+++ b/src/fuzzy.rs
@@ -39,9 +39,7 @@ pub fn rank_candidates(
             fuzzy_score(&normalized_query, &normalize(&combined), &normalize(title))
         };
 
-        candidate
-            .metadata
-            .insert("match".into(), score.to_string());
+        candidate.metadata.insert("match".into(), score.to_string());
     }
 
     candidates.retain(|candidate| {

--- a/src/fuzzy.rs
+++ b/src/fuzzy.rs
@@ -1,0 +1,221 @@
+use crate::player::SearchCandidate;
+
+pub const DEFAULT_THRESHOLD: u8 = 42;
+
+pub fn rank_candidates(
+    query: &str,
+    mut candidates: Vec<SearchCandidate>,
+    exact: bool,
+    threshold: u8,
+) -> Vec<SearchCandidate> {
+    let normalized_query = normalize(query);
+
+    for candidate in &mut candidates {
+        let title = candidate.metadata.get("title").map(String::as_str).unwrap_or("");
+        let artist = candidate.metadata.get("artist").map(String::as_str).unwrap_or("");
+        let combined = if artist.is_empty() {
+            title.to_string()
+        } else {
+            format!("{artist} {title}")
+        };
+
+        let score = if exact {
+            let normalized_title = normalize(title);
+            let normalized_combined = normalize(&combined);
+            if normalized_query == normalized_title || normalized_query == normalized_combined {
+                100
+            } else {
+                0
+            }
+        } else {
+            fuzzy_score(&normalized_query, &normalize(&combined), &normalize(title))
+        };
+
+        candidate.metadata.insert("match".into(), score.to_string());
+    }
+
+    candidates.retain(|candidate| {
+        candidate
+            .metadata
+            .get("match")
+            .and_then(|score| score.parse::<u8>().ok())
+            .is_some_and(|score| score >= threshold)
+    });
+
+    candidates.sort_by(|a, b| {
+        let a_score = a
+            .metadata
+            .get("match")
+            .and_then(|score| score.parse::<u8>().ok())
+            .unwrap_or(0);
+        let b_score = b
+            .metadata
+            .get("match")
+            .and_then(|score| score.parse::<u8>().ok())
+            .unwrap_or(0);
+        b_score
+            .cmp(&a_score)
+            .then_with(|| version_penalty(a).cmp(&version_penalty(b)))
+            .then_with(|| popularity(b).cmp(&popularity(a)))
+            .then_with(|| a.uri.cmp(&b.uri))
+    });
+
+    candidates
+}
+
+fn fuzzy_score(query: &str, combined: &str, title: &str) -> u8 {
+    if query.is_empty() || combined.is_empty() {
+        return 0;
+    }
+
+    let combined_edit = normalized_edit_similarity(query, combined);
+    let title_edit = normalized_edit_similarity(query, title);
+    let token = token_similarity(query, combined);
+    let containment = if combined.contains(query) || query.contains(combined) {
+        1.0
+    } else {
+        0.0
+    };
+
+    let score = combined_edit * 0.45 + title_edit * 0.20 + token * 0.30 + containment * 0.05;
+    (score * 100.0).round().clamp(0.0, 100.0) as u8
+}
+
+fn normalized_edit_similarity(a: &str, b: &str) -> f64 {
+    let max_len = a.chars().count().max(b.chars().count());
+    if max_len == 0 {
+        return 1.0;
+    }
+    let distance = levenshtein(a, b);
+    1.0 - distance as f64 / max_len as f64
+}
+
+fn token_similarity(a: &str, b: &str) -> f64 {
+    let a_tokens = a.split_whitespace().collect::<Vec<_>>();
+    let b_tokens = b.split_whitespace().collect::<Vec<_>>();
+    if a_tokens.is_empty() || b_tokens.is_empty() {
+        return 0.0;
+    }
+
+    let mut matched = 0.0;
+    for token in &a_tokens {
+        let best = b_tokens
+            .iter()
+            .map(|candidate| normalized_edit_similarity(token, candidate))
+            .fold(0.0, f64::max);
+        if best >= 0.55 {
+            matched += best;
+        }
+    }
+
+    matched / a_tokens.len().max(b_tokens.len()) as f64
+}
+
+fn levenshtein(a: &str, b: &str) -> usize {
+    let b_chars = b.chars().collect::<Vec<_>>();
+    let mut previous = (0..=b_chars.len()).collect::<Vec<_>>();
+
+    for (i, a_char) in a.chars().enumerate() {
+        let mut current = vec![i + 1];
+        for (j, b_char) in b_chars.iter().enumerate() {
+            let insert = current[j] + 1;
+            let delete = previous[j + 1] + 1;
+            let replace = previous[j] + usize::from(a_char != *b_char);
+            current.push(insert.min(delete).min(replace));
+        }
+        previous = current;
+    }
+
+    previous[b_chars.len()]
+}
+
+pub fn normalize(value: &str) -> String {
+    value
+        .chars()
+        .flat_map(char::to_lowercase)
+        .map(|ch| if ch.is_alphanumeric() { ch } else { ' ' })
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn version_penalty(candidate: &SearchCandidate) -> u8 {
+    let haystack = format!(
+        "{} {} {}",
+        candidate.metadata.get("title").map(String::as_str).unwrap_or(""),
+        candidate.metadata.get("album").map(String::as_str).unwrap_or(""),
+        candidate.metadata.get("version").map(String::as_str).unwrap_or("")
+    )
+    .to_lowercase();
+
+    [
+        "live",
+        "remaster",
+        "acoustic",
+        "demo",
+        "karaoke",
+        "tribute",
+        "instrumental",
+        "radio edit",
+        "re-record",
+    ]
+    .iter()
+    .filter(|marker| haystack.contains(**marker))
+    .count() as u8
+}
+
+fn popularity(candidate: &SearchCandidate) -> i32 {
+    candidate
+        .metadata
+        .get("popularity")
+        .and_then(|value| value.parse::<i32>().ok())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    fn candidate(title: &str, artist: &str) -> SearchCandidate {
+        SearchCandidate {
+            uri: format!("spotify:track:{title}"),
+            metadata: BTreeMap::from([
+                ("title".into(), title.into()),
+                ("artist".into(), artist.into()),
+                ("album".into(), "Paranoid".into()),
+                ("popularity".into(), "80".into()),
+            ]),
+        }
+    }
+
+    #[test]
+    fn tolerates_typo_in_artist_and_title() {
+        let ranked = rank_candidates(
+            "black sabath war pig",
+            vec![candidate("War Pigs", "Black Sabbath")],
+            false,
+            DEFAULT_THRESHOLD,
+        );
+        assert_eq!(ranked.len(), 1);
+        let score = ranked[0].metadata["match"].parse::<u8>().unwrap();
+        assert!(score >= 70, "score was {score}");
+    }
+
+    #[test]
+    fn exact_mode_rejects_typo() {
+        let ranked = rank_candidates(
+            "black sabath war pig",
+            vec![candidate("War Pigs", "Black Sabbath")],
+            true,
+            100,
+        );
+        assert!(ranked.is_empty());
+    }
+
+    #[test]
+    fn normalizes_punctuation_and_case() {
+        assert_eq!(normalize("WAR-PIGS!!"), "war pigs");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,9 +71,9 @@ fn parse_search(args: &[String]) -> Result<Command, RiffError> {
                 index += 1;
             }
             "--limit" => {
-                let value = args.get(index + 1).ok_or_else(|| {
-                    RiffError::Usage("search --limit requires a value".into())
-                })?;
+                let value = args
+                    .get(index + 1)
+                    .ok_or_else(|| RiffError::Usage("search --limit requires a value".into()))?;
                 limit = value.parse::<usize>().map_err(|_| {
                     RiffError::Usage("search --limit must be a positive integer".into())
                 })?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 use std::{fmt, fs, io, io::Write, path::PathBuf};
 
+pub mod fuzzy;
 pub mod player;
 
 const DEFAULT_PLAYLIST: &str = r#"playlist "my-playlist" {
@@ -18,7 +19,12 @@ pub enum Command {
     Inspect(PathBuf),
     Play(PathBuf),
     Player(Option<String>),
-    Search { query: String, limit: usize },
+    Search {
+        query: String,
+        limit: usize,
+        exact: bool,
+        threshold: u8,
+    },
     InspectTrack(String),
     Pick(String),
 }
@@ -37,24 +43,7 @@ impl Command {
             [cmd, path] if cmd == "play" => Ok(Self::Play(path.into())),
             [cmd] if cmd == "player" => Ok(Self::Player(None)),
             [cmd, uri] if cmd == "player" => Ok(Self::Player(Some(uri.clone()))),
-            [cmd, query] if cmd == "search" => Ok(Self::Search {
-                query: query.clone(),
-                limit: 10,
-            }),
-            [cmd, query, flag, limit] if cmd == "search" && flag == "--limit" => {
-                let limit = limit.parse::<usize>().map_err(|_| {
-                    RiffError::Usage("search --limit must be a positive integer".into())
-                })?;
-                if limit == 0 {
-                    return Err(RiffError::Usage(
-                        "search --limit must be greater than zero".into(),
-                    ));
-                }
-                Ok(Self::Search {
-                    query: query.clone(),
-                    limit,
-                })
-            }
+            [cmd, rest @ ..] if cmd == "search" => parse_search(rest),
             [cmd, uri] if cmd == "inspect-track" => Ok(Self::InspectTrack(uri.clone())),
             [cmd, query] if cmd == "pick" => Ok(Self::Pick(query.clone())),
             _ => Err(RiffError::Usage(
@@ -62,6 +51,62 @@ impl Command {
             )),
         }
     }
+}
+
+fn parse_search(args: &[String]) -> Result<Command, RiffError> {
+    let Some(query) = args.first() else {
+        return Err(RiffError::Usage("search requires a query".into()));
+    };
+
+    let mut limit = 10usize;
+    let mut exact = false;
+    let mut threshold = fuzzy::DEFAULT_THRESHOLD;
+    let mut index = 1;
+
+    while index < args.len() {
+        match args[index].as_str() {
+            "--exact" => {
+                exact = true;
+                threshold = 100;
+                index += 1;
+            }
+            "--limit" => {
+                let value = args.get(index + 1).ok_or_else(|| {
+                    RiffError::Usage("search --limit requires a value".into())
+                })?;
+                limit = value.parse::<usize>().map_err(|_| {
+                    RiffError::Usage("search --limit must be a positive integer".into())
+                })?;
+                if limit == 0 {
+                    return Err(RiffError::Usage(
+                        "search --limit must be greater than zero".into(),
+                    ));
+                }
+                index += 2;
+            }
+            "--threshold" => {
+                let value = args.get(index + 1).ok_or_else(|| {
+                    RiffError::Usage("search --threshold requires a value from 0 to 100".into())
+                })?;
+                threshold = value.parse::<u8>().map_err(|_| {
+                    RiffError::Usage("search --threshold must be from 0 to 100".into())
+                })?;
+                index += 2;
+            }
+            unknown => {
+                return Err(RiffError::Usage(format!(
+                    "unknown search option `{unknown}`"
+                )));
+            }
+        }
+    }
+
+    Ok(Command::Search {
+        query: query.clone(),
+        limit,
+        exact,
+        threshold,
+    })
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -289,12 +334,19 @@ pub async fn run(command: Command) -> Result<String, RiffError> {
             player::run(options).await.map_err(RiffError::Player)?;
             Ok(String::new())
         }
-        Command::Search { query, limit } => {
-            let candidates = player::search(&query, limit)
+        Command::Search {
+            query,
+            limit,
+            exact,
+            threshold,
+        } => {
+            let candidates = player::search_advanced(&query, limit, exact, threshold)
                 .await
                 .map_err(RiffError::Player)?;
             if candidates.is_empty() {
-                return Ok(format!("No Spotify tracks found for `{query}`."));
+                return Ok(format!(
+                    "No Spotify tracks matched `{query}` at the requested confidence."
+                ));
             }
             Ok(format_candidates(&query, &candidates))
         }
@@ -326,7 +378,7 @@ pub async fn run(command: Command) -> Result<String, RiffError> {
             let candidate = &candidates[selection - 1];
             Ok(format!(
                 "track \"{}\" id=\"{}\"",
-                escape_riff_string(&query),
+                escape_riff_string(&candidate.display_name()),
                 candidate.uri
             ))
         }
@@ -336,33 +388,42 @@ pub async fn run(command: Command) -> Result<String, RiffError> {
 fn format_candidates(query: &str, candidates: &[player::SearchCandidate]) -> String {
     let mut lines = vec![format!("Spotify recordings for `{query}`:")];
     for (index, candidate) in candidates.iter().enumerate() {
+        let confidence = candidate
+            .metadata
+            .get("match")
+            .map(String::as_str)
+            .unwrap_or("?");
         lines.push(format!(
-            "\n{}. {}\n   id: {}",
+            "\n{}. {}  [{confidence}% match]",
             index + 1,
-            candidate.display_name(),
-            candidate.uri
+            candidate.display_name()
         ));
-        for (key, value) in candidate.metadata.iter().take(6) {
-            lines.push(format!("   {key}: {value}"));
+
+        for key in ["album", "version", "duration", "popularity"] {
+            if let Some(value) = candidate.metadata.get(key) {
+                lines.push(format!("   {key}: {value}"));
+            }
         }
+        lines.push(format!("   id: {}", candidate.uri));
     }
     lines.join("\n")
 }
 
 fn format_candidate_details(candidate: &player::SearchCandidate) -> String {
-    let mut lines = vec![format!(
-        "{}\nid: {}",
-        candidate.display_name(),
-        candidate.uri
-    )];
-    if candidate.metadata.is_empty() {
-        lines.push("metadata: not returned by Spotify context resolver".to_string());
-    } else {
-        lines.push("metadata:".to_string());
-        for (key, value) in &candidate.metadata {
-            lines.push(format!("  {key}: {value}"));
+    let mut lines = vec![candidate.display_name()];
+    for key in [
+        "album",
+        "version",
+        "duration",
+        "popularity",
+        "original_title",
+        "match",
+    ] {
+        if let Some(value) = candidate.metadata.get(key) {
+            lines.push(format!("{key}: {value}"));
         }
     }
+    lines.push(format!("id: {}", candidate.uri));
     lines.join("\n")
 }
 
@@ -387,14 +448,14 @@ fn init(path: PathBuf) -> Result<String, RiffError> {
 
 pub fn help() -> String {
     format!(
-        "riff {}\nMusic as code, from the terminal.\n\nUSAGE:\n  riff <COMMAND>\n\nCOMMANDS:\n  init [file]         Create a starter playlist (default: playlist.riff)\n  doctor              Check the local Riff environment\n  validate <file>     Validate a .riff playlist\n  inspect <file>      Parse and print a .riff playlist\n  play <file>         Resolve a .riff playlist on Spotify and start playback\n  search <query>      Explore Spotify recordings and stable track IDs\n  inspect-track <id>  Inspect one Spotify track ID\n  pick <query>        Interactively choose a recording and print pinned DSL\n  player [uri]        Start Riff as a local Spotify Connect player\n  help                Print this help\n  version             Print version",
+        "riff {}\nMusic as code, from the terminal.\n\nUSAGE:\n  riff <COMMAND>\n\nCOMMANDS:\n  init [file]         Create a starter playlist (default: playlist.riff)\n  doctor              Check the local Riff environment\n  validate <file>     Validate a .riff playlist\n  inspect <file>      Parse and print a .riff playlist\n  play <file>         Resolve a .riff playlist on Spotify and start playback\n  search <query>      Smart fuzzy search (optional: --limit N --threshold 0-100 --exact)\n  inspect-track <id>  Inspect one Spotify track ID\n  pick <query>        Interactively choose a recording and print pinned DSL\n  player [uri]        Start Riff as a local Spotify Connect player\n  help                Print this help\n  version             Print version",
         env!("CARGO_PKG_VERSION")
     )
 }
 
 fn doctor() -> String {
     format!(
-        "Riff doctor\n  version      {}\n  platform     {}-{}\n  playlist DSL ready\n  spotify      player + discovery + pinned track ids available (Premium required)\n  playback     librespot / local audio backend",
+        "Riff doctor\n  version      {}\n  platform     {}-{}\n  playlist DSL ready\n  spotify      player + fuzzy discovery + pinned track ids available (Premium required)\n  playback     librespot / local audio backend",
         env!("CARGO_PKG_VERSION"),
         std::env::consts::OS,
         std::env::consts::ARCH
@@ -488,10 +549,26 @@ mod tests {
     }
 
     #[test]
-    fn parses_search_limit() {
+    fn search_is_fuzzy_by_default() {
+        let args = vec!["search".to_string(), "black sabath war pig".to_string()];
+        assert_eq!(
+            Command::parse(&args).expect("command should parse"),
+            Command::Search {
+                query: "black sabath war pig".to_string(),
+                limit: 10,
+                exact: false,
+                threshold: fuzzy::DEFAULT_THRESHOLD,
+            }
+        );
+    }
+
+    #[test]
+    fn parses_search_controls_in_any_order() {
         let args = vec![
             "search".to_string(),
             "War Pigs".to_string(),
+            "--threshold".to_string(),
+            "80".to_string(),
             "--limit".to_string(),
             "20".to_string(),
         ];
@@ -499,7 +576,27 @@ mod tests {
             Command::parse(&args).expect("command should parse"),
             Command::Search {
                 query: "War Pigs".to_string(),
-                limit: 20
+                limit: 20,
+                exact: false,
+                threshold: 80,
+            }
+        );
+    }
+
+    #[test]
+    fn parses_exact_search() {
+        let args = vec![
+            "search".to_string(),
+            "Black Sabbath War Pigs".to_string(),
+            "--exact".to_string(),
+        ];
+        assert_eq!(
+            Command::parse(&args).expect("command should parse"),
+            Command::Search {
+                query: "Black Sabbath War Pigs".to_string(),
+                limit: 10,
+                exact: true,
+                threshold: 100,
             }
         );
     }

--- a/src/player.rs
+++ b/src/player.rs
@@ -199,8 +199,8 @@ async fn resolve_tracks(session: &Session, tracks: &[TrackRequest]) -> Result<Ve
             tracks.len(),
             track.label
         );
-        let candidates = smart_search_with_session(session, &track.label, 1, false, DEFAULT_THRESHOLD)
-            .await?;
+        let candidates =
+            smart_search_with_session(session, &track.label, 1, false, DEFAULT_THRESHOLD).await?;
         let candidate = candidates
             .into_iter()
             .next()

--- a/src/player.rs
+++ b/src/player.rs
@@ -1,5 +1,6 @@
 use std::{collections::BTreeMap, env, fs, path::PathBuf};
 
+use crate::fuzzy::{DEFAULT_THRESHOLD, rank_candidates};
 use env_logger::Env;
 use librespot::{
     connect::{ConnectConfig, LoadRequest, LoadRequestOptions, Spirc},
@@ -24,6 +25,7 @@ const OAUTH_SCOPES: &[&str] = &[
     "user-read-playback-state",
     "user-modify-playback-state",
 ];
+const FUZZY_CANDIDATE_POOL: usize = 30;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TrackRequest {
@@ -146,9 +148,18 @@ pub async fn run(options: PlayerOptions) -> Result<(), String> {
 }
 
 pub async fn search(query: &str, limit: usize) -> Result<Vec<SearchCandidate>, String> {
+    search_advanced(query, limit, false, DEFAULT_THRESHOLD).await
+}
+
+pub async fn search_advanced(
+    query: &str,
+    limit: usize,
+    exact: bool,
+    threshold: u8,
+) -> Result<Vec<SearchCandidate>, String> {
     init_logging();
     let session = discovery_session().await?;
-    let result = search_with_session(&session, query, limit).await;
+    let result = smart_search_with_session(&session, query, limit, exact, threshold).await;
     session.shutdown();
     result
 }
@@ -188,12 +199,22 @@ async fn resolve_tracks(session: &Session, tracks: &[TrackRequest]) -> Result<Ve
             tracks.len(),
             track.label
         );
-        let candidates = search_with_session(session, &track.label, 1).await?;
+        let candidates = smart_search_with_session(session, &track.label, 1, false, DEFAULT_THRESHOLD)
+            .await?;
         let candidate = candidates
             .into_iter()
             .next()
-            .ok_or_else(|| format!("no Spotify track found for `{}`", track.label))?;
-        println!("       -> {} ({})", candidate.display_name(), candidate.uri);
+            .ok_or_else(|| format!("no confident Spotify track found for `{}`", track.label))?;
+        let confidence = candidate
+            .metadata
+            .get("match")
+            .map(String::as_str)
+            .unwrap_or("?");
+        println!(
+            "       -> {} ({}, {confidence}% match)",
+            candidate.display_name(),
+            candidate.uri
+        );
         resolved.push(candidate.uri);
     }
 
@@ -232,6 +253,20 @@ fn session_parts() -> Result<(SessionConfig, Cache, Credentials), String> {
     };
 
     Ok((session_config, cache, credentials))
+}
+
+async fn smart_search_with_session(
+    session: &Session,
+    query: &str,
+    limit: usize,
+    exact: bool,
+    threshold: u8,
+) -> Result<Vec<SearchCandidate>, String> {
+    let pool_size = FUZZY_CANDIDATE_POOL.max(limit.saturating_mul(3));
+    let raw = search_with_session(session, query, pool_size).await?;
+    let mut ranked = rank_candidates(query, raw, exact, threshold);
+    ranked.truncate(limit);
+    Ok(ranked)
 }
 
 async fn search_with_session(


### PR DESCRIPTION
Make Riff search forgiving by default while keeping deterministic provider IDs.

- fuzzy search is the default for `riff search`
- tolerate typos, punctuation differences, missing words, and token-order variation
- rank a larger Spotify candidate pool locally using edit similarity + token similarity
- show a confidence percentage in search output
- prefer normal studio/original-looking results over live/remaster/demo/etc. when scores tie
- use the same fuzzy ranking when resolving unpinned `.riff` tracks for playback
- add optional `--exact`, `--threshold 0-100`, and existing `--limit N` controls
- keep `riff pick` fuzzy by default and emit the actual resolved display name with the pinned ID
- add unit tests for typo tolerance, exact matching, normalization, and CLI flags
- bump Riff to 0.3.2