### PR TITLE
feat(platform): support Windows 11 and WSL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   quality:
-    name: fmt, clippy, test
+    name: Linux quality
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -20,7 +20,7 @@ jobs:
         run: bash -n install.sh scripts/deps.sh
 
       - name: Install Linux audio dependencies
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev pkg-config
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev libpulse-dev pkg-config
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -32,6 +32,37 @@ jobs:
 
       - name: Check dependency helper
         run: bash scripts/deps.sh check
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Test
+        run: cargo test --all-features
+
+      - name: Check
+        run: cargo check --all-targets --all-features
+
+  windows:
+    name: Windows 11 compatible build
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Validate PowerShell installer
+        shell: pwsh
+        run: $null = [scriptblock]::Create((Get-Content -Raw ./install.ps1))
 
       - name: Check formatting
         run: cargo fmt --all -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riff"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 description = "A terminal-first music player where playlists are code."
 license = "MIT"
@@ -13,10 +13,15 @@ categories = ["command-line-utilities", "multimedia::audio"]
 [dependencies]
 crossterm = "0.29"
 env_logger = "0.11"
-librespot = { version = "0.8.0", default-features = false, features = ["rodio-backend", "rustls-tls-native-roots"] }
 log = "0.4"
 ratatui = "0.30.2"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "sync", "time"] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+librespot = { version = "0.8.0", default-features = false, features = ["rodio-backend", "rustls-tls-native-roots"] }
+
+[target.'cfg(not(target_os = "windows"))'.dependencies]
+librespot = { version = "0.8.0", default-features = false, features = ["rodio-backend", "pulseaudio-backend", "rustls-tls-native-roots"] }
 
 # librespot 0.8.0's build script is incompatible with vergen 9.1.x.
 # Keep this exact pin until a crates.io librespot release includes upstream fix #1683.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,13 +2,15 @@
 
 Riff is currently distributed straight from GitHub while the project is in early development.
 
-## One-line install (Linux)
+## Linux and WSL
+
+Install the latest build from `main`:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Nicolas25vlad/riff/main/install.sh | bash
 ```
 
-The installer checks the Rust/Git requirements and provisions the native Linux audio build dependencies on Arch/Omarchy, Debian/Ubuntu, and Fedora-family systems when they are missing.
+The installer checks Rust/Git and provisions the native audio build dependencies on Arch/Omarchy, Debian/Ubuntu, Fedora-family systems and WSL distributions based on them.
 
 For Fish, if needed:
 
@@ -16,107 +18,119 @@ For Fish, if needed:
 fish_add_path $HOME/.cargo/bin
 ```
 
-Verify the installation:
+Verify:
 
 ```bash
 riff --version
 riff doctor
+riff tui playlist.riff
+```
+
+### WSL audio
+
+On WSL2 with WSLg, Riff detects the WSL environment and prefers its compiled PulseAudio backend when `PULSE_SERVER` is available. WSLg forwards that audio to the Windows host.
+
+You normally do not need to configure audio manually. To inspect the environment:
+
+```bash
+printf '%s\n' "$WSL_DISTRO_NAME" "$PULSE_SERVER"
+```
+
+If you intentionally want to override automatic audio selection, set `RIFF_AUDIO_BACKEND`, for example:
+
+```bash
+RIFF_AUDIO_BACKEND=rodio riff tui playlist.riff
+```
+
+## Windows 11 native
+
+Requirements:
+
+- Git for Windows
+- Rust stable with Cargo
+- a working MSVC Rust toolchain/build environment
+
+From PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/Nicolas25vlad/riff/main/install.ps1 | iex
+```
+
+Or install directly with Cargo:
+
+```powershell
+cargo install --git https://github.com/Nicolas25vlad/riff --force
+```
+
+Riff uses librespot's Rodio backend on Windows, which outputs through the native Windows audio stack. Spotify credentials/cache are stored under `%LOCALAPPDATA%\Riff\spotify` when available.
+
+Verify:
+
+```powershell
+riff --version
+riff doctor
+riff tui playlist.riff
 ```
 
 ## Project dependencies
 
-When working from a cloned checkout, Riff includes a small dependency helper:
+From a cloned Linux/WSL checkout:
 
 ```bash
 bash scripts/deps.sh install
 ```
 
-That installs missing native/system dependencies and runs `cargo fetch` for the Rust dependency graph.
-
-Other useful commands:
+Useful commands:
 
 ```bash
-# Update Rust crates within Cargo.toml constraints
 bash scripts/deps.sh update
-
-# Validate the dependency graph and compile all targets/features
 bash scripts/deps.sh check
-
-# Install only native/system dependencies
 bash scripts/deps.sh native
-
-# Fetch only Rust crates
 bash scripts/deps.sh rust
 ```
 
-`update` runs `cargo update`, so review `Cargo.lock` before committing dependency changes once the root lockfile is versioned.
+On Windows, use Cargo directly:
 
-## Linux audio dependencies
+```powershell
+cargo fetch
+cargo check --all-targets --all-features
+cargo test --all-features
+```
 
-Riff's first playback backend uses `librespot` with Rodio. On Linux this builds against ALSA.
+## Linux / WSL audio dependencies
+
+Riff compiles Rodio plus PulseAudio support on Linux. Rodio remains the normal Linux default; WSLg prefers PulseAudio automatically.
 
 Manual packages:
 
 ```bash
 # Arch / Omarchy
-sudo pacman -S --needed base-devel alsa-lib pkgconf
+sudo pacman -S --needed base-devel alsa-lib libpulse pkgconf
 
-# Debian / Ubuntu
-sudo apt-get install build-essential libasound2-dev pkg-config
+# Debian / Ubuntu / WSL Ubuntu
+sudo apt-get install build-essential libasound2-dev libpulse-dev pkg-config
 
 # Fedora
-sudo dnf install gcc make alsa-lib-devel pkgconf-pkg-config
+sudo dnf install gcc make alsa-lib-devel pulseaudio-libs-devel pkgconf-pkg-config
 ```
 
-The one-line installer and `bash scripts/deps.sh install` handle these automatically when necessary.
+## Start the player
 
-## Install with Cargo
+Spotify playback requires Spotify Premium because Riff uses `librespot`.
 
-Requirements:
-
-- Git
-- Rust stable and Cargo
-- Linux audio build dependencies listed above
-
-Install the latest `main` build:
-
-```bash
-cargo install --git https://github.com/Nicolas25vlad/riff
-```
-
-Make sure Cargo's binary directory is on your `PATH`:
-
-```bash
-export PATH="$HOME/.cargo/bin:$PATH"
-```
-
-For Fish:
-
-```fish
-fish_add_path $HOME/.cargo/bin
-```
-
-## Start the Spotify player
-
-Spotify playback requires a Spotify Premium account because Riff uses `librespot`.
-
-Start Riff as a local Spotify Connect device:
+Headless Spotify Connect device:
 
 ```bash
 riff player
 ```
 
-On the first run, Riff opens Spotify authorization in your browser. After authentication, the session is cached under your XDG cache directory (normally `~/.cache/riff/spotify`) so you do not need to log in every time.
-
-Once the terminal prints that the player is online, select **Riff** from Spotify Connect on any Spotify client connected to your account.
-
-You can also ask Riff to load a Spotify context URI when it starts:
+Play a `.riff` playlist with the terminal UI:
 
 ```bash
-riff player 'spotify:album:1ATL5GLyefJaxhQzSPVrLX'
+riff tui playlist.riff
 ```
 
-Press `Ctrl+C` to stop the headless player.
+On first authentication, Riff opens Spotify authorization in the browser and caches the resulting credentials.
 
 ## Playlist DSL
 
@@ -126,7 +140,7 @@ Create a starter playlist:
 riff init
 ```
 
-That creates `playlist.riff` in the current directory:
+Example:
 
 ```riff
 playlist "my-playlist" {
@@ -142,27 +156,13 @@ riff validate playlist.riff
 riff inspect playlist.riff
 ```
 
-You can also choose the file name when initializing:
-
-```bash
-riff init coding-metal.riff
-```
-
-Riff refuses to overwrite an existing file.
-
-The bridge from textual `.riff` tracks to Spotify search/queue playback is the next player milestone. For now, `.riff` tooling and the Spotify Connect player are separate surfaces.
-
 ## Update
-
-Until packaged releases are available, update by reinstalling from GitHub:
 
 ```bash
 cargo install --git https://github.com/Nicolas25vlad/riff --force
 ```
 
-You can also rerun the one-line installer. It uses `--force`, so an existing installation is replaced by the latest `main` build.
-
-A versioned root `Cargo.lock` and fully locked installs are tracked in issue #13. The known `librespot 0.8.0`/`vergen` resolution problem is pinned explicitly in `Cargo.toml` in the meantime.
+You can also rerun the platform installer.
 
 ## Uninstall
 
@@ -172,6 +172,8 @@ cargo uninstall riff
 
 ## Build from source
 
+Linux / WSL:
+
 ```bash
 git clone https://github.com/Nicolas25vlad/riff.git
 cd riff
@@ -179,12 +181,12 @@ bash scripts/deps.sh install
 cargo build --release
 ```
 
-The resulting binary will be available at:
+Windows PowerShell:
 
-```text
-target/release/riff
+```powershell
+git clone https://github.com/Nicolas25vlad/riff.git
+cd riff
+cargo build --release
 ```
 
-## Current limitations
-
-The v0.2 player foundation provides local Spotify Connect playback and the existing playlist DSL tools. Direct `.riff` resolution, queue control, the Ratatui interface, album artwork and audio-reactive visualization are tracked as subsequent milestones.
+The binary is written under `target/release/` (`riff` on Unix-like systems, `riff.exe` on Windows).

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,40 @@
+$ErrorActionPreference = "Stop"
+
+$Repo = "https://github.com/Nicolas25vlad/riff"
+
+function Write-Step([string]$Message) {
+    Write-Host $Message -ForegroundColor Cyan
+}
+
+function Fail([string]$Message) {
+    Write-Error $Message
+    exit 1
+}
+
+if (-not (Get-Command cargo -ErrorAction SilentlyContinue)) {
+    Fail "Cargo was not found. Install Rust with rustup first, then re-run this installer."
+}
+
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    Fail "Git was not found. Install Git for Windows first, then re-run this installer."
+}
+
+Write-Step "Installing Riff from GitHub..."
+cargo install --git $Repo --force
+
+$CargoHome = if ($env:CARGO_HOME) { $env:CARGO_HOME } else { Join-Path $HOME ".cargo" }
+$BinDir = Join-Path $CargoHome "bin"
+
+if (-not (Get-Command riff -ErrorAction SilentlyContinue)) {
+    Write-Warning "Riff was installed to $BinDir, but that directory is not currently in PATH."
+    Write-Host "Add it to your user PATH, then open a new terminal."
+} else {
+    Write-Step "Riff installed successfully."
+    riff --version
+}
+
+Write-Host ""
+Write-Host "Try it:"
+Write-Host "  riff doctor"
+Write-Host "  riff init"
+Write-Host "  riff tui playlist.riff"

--- a/install.sh
+++ b/install.sh
@@ -24,21 +24,23 @@ command -v git >/dev/null 2>&1 || fail "git is required"
 install_linux_audio_deps() {
   [ "$(uname -s)" = "Linux" ] || return 0
 
-  if command -v pkg-config >/dev/null 2>&1 && pkg-config --exists alsa; then
+  if command -v pkg-config >/dev/null 2>&1 \
+    && pkg-config --exists alsa \
+    && pkg-config --exists libpulse; then
     return 0
   fi
 
-  say "Installing Linux audio build dependencies..."
+  say "Installing Linux/WSL audio build dependencies..."
 
   if command -v pacman >/dev/null 2>&1; then
-    sudo pacman -S --needed --noconfirm base-devel alsa-lib pkgconf
+    sudo pacman -S --needed --noconfirm base-devel alsa-lib libpulse pkgconf
   elif command -v apt-get >/dev/null 2>&1; then
     sudo apt-get update
-    sudo apt-get install -y build-essential libasound2-dev pkg-config
+    sudo apt-get install -y build-essential libasound2-dev libpulse-dev pkg-config
   elif command -v dnf >/dev/null 2>&1; then
-    sudo dnf install -y gcc make alsa-lib-devel pkgconf-pkg-config
+    sudo dnf install -y gcc make alsa-lib-devel pulseaudio-libs-devel pkgconf-pkg-config
   else
-    fail "Riff needs an ALSA development package and pkg-config to build its Linux audio backend. Install them with your distro package manager and run this installer again."
+    fail "Riff needs ALSA and PulseAudio development packages plus pkg-config to build on Linux/WSL. Install them with your distro package manager and run this installer again."
   fi
 }
 
@@ -72,4 +74,4 @@ else
   riff --version
 fi
 
-printf '\nTry it:\n  riff doctor\n  riff player\n  riff init\n  riff validate playlist.riff\n'
+printf '\nTry it:\n  riff doctor\n  riff player\n  riff init\n  riff tui playlist.riff\n'

--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -20,25 +20,30 @@ fail() {
 install_native_deps() {
   case "$(uname -s)" in
     Linux)
-      if command -v pkg-config >/dev/null 2>&1 && pkg-config --exists alsa; then
-        say "Native Linux audio dependencies are already installed."
+      if command -v pkg-config >/dev/null 2>&1 \
+        && pkg-config --exists alsa \
+        && pkg-config --exists libpulse; then
+        say "Native Linux/WSL audio dependencies are already installed."
         return 0
       fi
 
-      say "Installing native Linux audio dependencies..."
+      say "Installing native Linux/WSL audio dependencies..."
       if command -v pacman >/dev/null 2>&1; then
-        sudo pacman -S --needed --noconfirm base-devel alsa-lib pkgconf
+        sudo pacman -S --needed --noconfirm base-devel alsa-lib libpulse pkgconf
       elif command -v apt-get >/dev/null 2>&1; then
         sudo apt-get update
-        sudo apt-get install -y build-essential libasound2-dev pkg-config
+        sudo apt-get install -y build-essential libasound2-dev libpulse-dev pkg-config
       elif command -v dnf >/dev/null 2>&1; then
-        sudo dnf install -y gcc make alsa-lib-devel pkgconf-pkg-config
+        sudo dnf install -y gcc make alsa-lib-devel pulseaudio-libs-devel pkgconf-pkg-config
       else
-        fail "Unsupported Linux package manager. Install an ALSA development package, pkg-config and a C toolchain manually."
+        fail "Unsupported Linux package manager. Install ALSA and PulseAudio development packages, pkg-config and a C toolchain manually."
       fi
       ;;
     Darwin)
       say "macOS detected. No extra native package is required by this helper right now."
+      ;;
+    MINGW*|MSYS*|CYGWIN*)
+      say "Windows shell detected. Native audio dependencies are provided by the Windows/Rodio build."
       ;;
     *)
       warn "Automatic native dependency installation is not supported on this OS yet."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 use std::{fmt, fs, io, io::Write, path::PathBuf};
 
 pub mod fuzzy;
+pub mod platform;
 pub mod player;
 
 const DEFAULT_PLAYLIST: &str = r#"playlist "my-playlist" {

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,0 +1,92 @@
+use std::{env, fs, path::{Path, PathBuf}};
+
+use librespot::playback::audio_backend::{self, SinkBuilder};
+
+pub fn audio_sink_builder() -> Result<SinkBuilder, String> {
+    if let Some(name) = env::var_os("RIFF_AUDIO_BACKEND") {
+        let name = name.to_string_lossy().into_owned();
+        return audio_backend::find(Some(name.clone())).ok_or_else(|| {
+            format!("unsupported audio backend `{name}`; unset RIFF_AUDIO_BACKEND to use automatic selection")
+        });
+    }
+
+    if is_wsl() && env::var_os("PULSE_SERVER").is_some() {
+        return audio_backend::find(Some("pulseaudio".to_string())).ok_or_else(|| {
+            "WSL/WSLg was detected, but the PulseAudio backend is not available in this build"
+                .to_string()
+        });
+    }
+
+    audio_backend::find(None).ok_or_else(|| "no supported audio backend was found".to_string())
+}
+
+pub fn spotify_cache_dir() -> Result<PathBuf, String> {
+    if let Some(path) = env::var_os("XDG_CACHE_HOME") {
+        return Ok(PathBuf::from(path).join("riff").join("spotify"));
+    }
+
+    if cfg!(target_os = "windows") {
+        if let Some(path) = env::var_os("LOCALAPPDATA") {
+            return Ok(PathBuf::from(path).join("Riff").join("spotify"));
+        }
+        if let Some(path) = env::var_os("USERPROFILE") {
+            return Ok(PathBuf::from(path)
+                .join(".cache")
+                .join("riff")
+                .join("spotify"));
+        }
+    }
+
+    if let Some(path) = env::var_os("HOME") {
+        return Ok(PathBuf::from(path)
+            .join(".cache")
+            .join("riff")
+            .join("spotify"));
+    }
+
+    Err("could not determine a cache directory; set XDG_CACHE_HOME or a platform home directory"
+        .to_string())
+}
+
+pub fn is_wsl() -> bool {
+    if !cfg!(target_os = "linux") {
+        return false;
+    }
+
+    if env::var_os("WSL_INTEROP").is_some() || env::var_os("WSL_DISTRO_NAME").is_some() {
+        return true;
+    }
+
+    fs::read_to_string("/proc/sys/kernel/osrelease")
+        .map(|release| release.to_ascii_lowercase().contains("microsoft"))
+        .unwrap_or(false)
+}
+
+#[cfg(unix)]
+pub fn secure_cache_dir(path: &Path) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut permissions = fs::metadata(path)
+        .map_err(|err| format!("could not inspect Spotify cache permissions: {err}"))?
+        .permissions();
+    permissions.set_mode(0o700);
+    fs::set_permissions(path, permissions)
+        .map_err(|err| format!("could not secure Spotify cache directory: {err}"))
+}
+
+#[cfg(not(unix))]
+pub fn secure_cache_dir(_path: &Path) -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn non_linux_targets_are_not_wsl() {
+        if !cfg!(target_os = "linux") {
+            assert!(!is_wsl());
+        }
+    }
+}

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,4 +1,7 @@
-use std::{env, fs, path::{Path, PathBuf}};
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+};
 
 use librespot::playback::audio_backend::{self, SinkBuilder};
 
@@ -44,8 +47,10 @@ pub fn spotify_cache_dir() -> Result<PathBuf, String> {
             .join("spotify"));
     }
 
-    Err("could not determine a cache directory; set XDG_CACHE_HOME or a platform home directory"
-        .to_string())
+    Err(
+        "could not determine a cache directory; set XDG_CACHE_HOME or a platform home directory"
+            .to_string(),
+    )
 }
 
 pub fn is_wsl() -> bool {

--- a/src/player.rs
+++ b/src/player.rs
@@ -1,6 +1,9 @@
-use std::{collections::BTreeMap, env, fs, path::PathBuf};
+use std::{collections::BTreeMap, fs};
 
-use crate::fuzzy::{DEFAULT_THRESHOLD, rank_candidates};
+use crate::{
+    fuzzy::{DEFAULT_THRESHOLD, rank_candidates},
+    platform,
+};
 use env_logger::Env;
 use librespot::{
     connect::{ConnectConfig, LoadRequest, LoadRequestOptions, Spirc},
@@ -11,7 +14,6 @@ use librespot::{
     metadata::{Metadata, Track as SpotifyTrack},
     oauth::OAuthClientBuilder,
     playback::{
-        audio_backend,
         config::{AudioFormat, PlayerConfig},
         mixer,
         mixer::MixerConfig,
@@ -80,8 +82,7 @@ pub async fn run(options: PlayerOptions) -> Result<(), String> {
         ..ConnectConfig::default()
     };
 
-    let sink_builder = audio_backend::find(None)
-        .ok_or_else(|| "no supported audio backend was found".to_string())?;
+    let sink_builder = platform::audio_sink_builder()?;
     let mixer_builder =
         mixer::find(None).ok_or_else(|| "no supported audio mixer was found".to_string())?;
 
@@ -232,11 +233,11 @@ async fn discovery_session() -> Result<Session, String> {
 }
 
 fn session_parts() -> Result<(SessionConfig, Cache, Credentials), String> {
-    let cache_dir = cache_dir()?;
+    let cache_dir = platform::spotify_cache_dir()?;
     let files_dir = cache_dir.join("files");
     fs::create_dir_all(&files_dir)
         .map_err(|err| format!("could not create Spotify cache directory: {err}"))?;
-    secure_cache_dir(&cache_dir)?;
+    platform::secure_cache_dir(&cache_dir)?;
 
     let session_config = SessionConfig::default();
     let cache = Cache::new(
@@ -391,39 +392,6 @@ fn oauth_credentials(session_config: &SessionConfig) -> Result<Credentials, Stri
     .get_access_token()
     .map(|token| Credentials::with_access_token(token.access_token))
     .map_err(|err| format!("Spotify authorization failed: {err}"))
-}
-
-fn cache_dir() -> Result<PathBuf, String> {
-    if let Some(path) = env::var_os("XDG_CACHE_HOME") {
-        return Ok(PathBuf::from(path).join("riff").join("spotify"));
-    }
-
-    let home = env::var_os("HOME").ok_or_else(|| {
-        "HOME is not set; set HOME or XDG_CACHE_HOME so Riff can store Spotify credentials"
-            .to_string()
-    })?;
-
-    Ok(PathBuf::from(home)
-        .join(".cache")
-        .join("riff")
-        .join("spotify"))
-}
-
-#[cfg(unix)]
-fn secure_cache_dir(path: &std::path::Path) -> Result<(), String> {
-    use std::os::unix::fs::PermissionsExt;
-
-    let mut permissions = fs::metadata(path)
-        .map_err(|err| format!("could not inspect Spotify cache permissions: {err}"))?
-        .permissions();
-    permissions.set_mode(0o700);
-    fs::set_permissions(path, permissions)
-        .map_err(|err| format!("could not secure Spotify cache directory: {err}"))
-}
-
-#[cfg(not(unix))]
-fn secure_cache_dir(_path: &std::path::Path) -> Result<(), String> {
-    Ok(())
 }
 
 #[cfg(test)]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,4 +1,4 @@
-use std::{env, fs, io, path::PathBuf, time::Duration};
+use std::{fs, io, time::Duration};
 
 use crossterm::{
     event::{self, Event, KeyCode, KeyEventKind},
@@ -11,7 +11,6 @@ use librespot::{
     core::{authentication::Credentials, cache::Cache, config::SessionConfig, session::Session},
     oauth::OAuthClientBuilder,
     playback::{
-        audio_backend,
         config::{AudioFormat, PlayerConfig},
         mixer,
         mixer::MixerConfig,
@@ -26,7 +25,7 @@ use ratatui::{
     text::{Line, Span},
     widgets::{Block, Borders, Gauge, List, ListItem, Paragraph, Wrap},
 };
-use riff::{Playlist, player};
+use riff::{Playlist, platform, player};
 use tokio::sync::mpsc;
 
 const OAUTH_REDIRECT_URI: &str = "http://127.0.0.1:8898/login";
@@ -193,8 +192,7 @@ async fn run_player(
         ..ConnectConfig::default()
     };
 
-    let sink_builder = audio_backend::find(None)
-        .ok_or_else(|| "no supported audio backend was found".to_string())?;
+    let sink_builder = platform::audio_sink_builder()?;
     let mixer_builder =
         mixer::find(None).ok_or_else(|| "no supported audio mixer was found".to_string())?;
 
@@ -521,11 +519,11 @@ fn format_duration(duration_ms: u32) -> String {
 }
 
 fn session_parts() -> Result<(SessionConfig, Cache, Credentials), String> {
-    let cache_dir = cache_dir()?;
+    let cache_dir = platform::spotify_cache_dir()?;
     let files_dir = cache_dir.join("files");
     fs::create_dir_all(&files_dir)
         .map_err(|err| format!("could not create Spotify cache directory: {err}"))?;
-    secure_cache_dir(&cache_dir)?;
+    platform::secure_cache_dir(&cache_dir)?;
 
     let session_config = SessionConfig::default();
     let cache = Cache::new(
@@ -557,39 +555,6 @@ fn oauth_credentials(session_config: &SessionConfig) -> Result<Credentials, Stri
     .get_access_token()
     .map(|token| Credentials::with_access_token(token.access_token))
     .map_err(|err| format!("Spotify authorization failed: {err}"))
-}
-
-fn cache_dir() -> Result<PathBuf, String> {
-    if let Some(path) = env::var_os("XDG_CACHE_HOME") {
-        return Ok(PathBuf::from(path).join("riff").join("spotify"));
-    }
-
-    let home = env::var_os("HOME").ok_or_else(|| {
-        "HOME is not set; set HOME or XDG_CACHE_HOME so Riff can store Spotify credentials"
-            .to_string()
-    })?;
-
-    Ok(PathBuf::from(home)
-        .join(".cache")
-        .join("riff")
-        .join("spotify"))
-}
-
-#[cfg(unix)]
-fn secure_cache_dir(path: &std::path::Path) -> Result<(), String> {
-    use std::os::unix::fs::PermissionsExt;
-
-    let mut permissions = fs::metadata(path)
-        .map_err(|err| format!("could not inspect Spotify cache permissions: {err}"))?
-        .permissions();
-    permissions.set_mode(0o700);
-    fs::set_permissions(path, permissions)
-        .map_err(|err| format!("could not secure Spotify cache directory: {err}"))
-}
-
-#[cfg(not(unix))]
-fn secure_cache_dir(_path: &std::path::Path) -> Result<(), String> {
-    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Add first-class Windows 11 and WSL support around the new TUI/player foundation.

- add native Windows PowerShell installer (`install.ps1`)
- compile librespot Rodio backend on Windows and Rodio + PulseAudio on Linux/WSL
- detect WSL/WSLg and prefer PulseAudio when `PULSE_SERVER` is available
- keep `RIFF_AUDIO_BACKEND` as an explicit runtime override
- store Spotify cache under `%LOCALAPPDATA%\\Riff\\spotify` on Windows
- install PulseAudio development dependencies on Linux/WSL helpers
- add a `windows-latest` CI job with fmt, clippy, tests and cargo check
- document native Windows 11 and WSL setup
- bump Riff to 0.4.1

Windows native playback uses librespot/Rodio. WSLg playback uses its projected PulseAudio server when detected, with the normal backend retained outside WSL.