### PR TITLE
build(release): pause AUR and bootstrap crates.io 0.6.0

### DIFF
--- a/.github/workflows/package-check.yml
+++ b/.github/workflows/package-check.yml
@@ -4,9 +4,9 @@ on:
   pull_request:
     paths:
       - 'Cargo.toml'
-      - 'packaging/**'
       - '.github/workflows/package-check.yml'
       - '.github/workflows/publish-packages.yml'
+      - '.github/workflows/publish-crates-bootstrap.yml'
       - 'RELEASING.md'
   workflow_dispatch:
 
@@ -37,38 +37,3 @@ jobs:
 
       - name: Validate crate package
         run: cargo publish --dry-run
-
-  aur-package:
-    name: AUR metadata dry run
-    runs-on: ubuntu-latest
-    container: archlinux:base-devel
-    timeout-minutes: 15
-    steps:
-      - name: Install tools
-        run: pacman -Syu --noconfirm git
-
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Render PKGBUILD
-        shell: bash
-        run: |
-          set -euo pipefail
-          version=$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -n1)
-          test -n "$version"
-          zero_sha=$(printf '0%.0s' {1..64})
-          sed \
-            -e "s/@VERSION@/${version}/g" \
-            -e "s/@SHA256@/${zero_sha}/g" \
-            packaging/aur/PKGBUILD.template > packaging/aur/PKGBUILD
-          bash -n packaging/aur/PKGBUILD
-
-      - name: Generate SRCINFO
-        shell: bash
-        run: |
-          set -euo pipefail
-          useradd -m builder
-          chown -R builder:builder "$GITHUB_WORKSPACE"
-          runuser -u builder -- bash -lc "cd '$GITHUB_WORKSPACE/packaging/aur' && makepkg --printsrcinfo > .SRCINFO"
-          test -s packaging/aur/.SRCINFO
-          cat packaging/aur/.SRCINFO

--- a/.github/workflows/publish-crates-bootstrap.yml
+++ b/.github/workflows/publish-crates-bootstrap.yml
@@ -1,0 +1,57 @@
+name: Publish crates.io Bootstrap
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/publish-crates-bootstrap.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-crates-bootstrap
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish Riff 0.6.0 to crates.io
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+
+      - name: Install Linux audio dependencies
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev libpulse-dev pkg-config
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Require crates.io token
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${CARGO_REGISTRY_TOKEN:-}" ]]; then
+            echo '::error::Missing repository secret CARGO_REGISTRY_TOKEN.'
+            exit 1
+          fi
+
+      - name: Validate bootstrap version
+        shell: bash
+        run: |
+          set -euo pipefail
+          version=$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -n1)
+          if [[ "$version" != "0.6.0" ]]; then
+            echo "::error::Bootstrap publisher is pinned to 0.6.0 but Cargo.toml contains $version."
+            exit 1
+          fi
+          echo "Publishing Riff $version"
+
+      - name: Final crates.io dry run
+        run: cargo publish --dry-run
+
+      - name: Publish crates.io
+        run: cargo publish --token "$CARGO_REGISTRY_TOKEN"

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -37,7 +37,7 @@ jobs:
             exit 1
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "Publishing Riff $version"
+          echo "Publishing Riff $version to crates.io"
 
   crates-io:
     name: Publish crates.io
@@ -64,6 +64,7 @@ jobs:
       - name: Require crates.io token
         shell: bash
         run: |
+          set -euo pipefail
           if [[ -z "${CARGO_REGISTRY_TOKEN:-}" ]]; then
             echo '::error::Missing repository secret CARGO_REGISTRY_TOKEN.'
             exit 1
@@ -74,80 +75,3 @@ jobs:
 
       - name: Publish crates.io
         run: cargo publish --token "$CARGO_REGISTRY_TOKEN"
-
-  aur:
-    name: Publish AUR
-    needs: validate-release
-    runs-on: ubuntu-latest
-    container: archlinux:base-devel
-    timeout-minutes: 20
-    env:
-      AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
-    steps:
-      - name: Install release tools
-        run: pacman -Syu --noconfirm git openssh curl
-
-      - name: Checkout release tag
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.release.tag_name }}
-
-      - name: Render AUR package
-        shell: bash
-        run: |
-          set -euo pipefail
-          version='${{ needs.validate-release.outputs.version }}'
-          archive_url="https://github.com/Nicolas25vlad/riff/archive/refs/tags/v${version}.tar.gz"
-          curl -fL "$archive_url" -o /tmp/riff-source.tar.gz
-          source_sha=$(sha256sum /tmp/riff-source.tar.gz | awk '{print $1}')
-          sed \
-            -e "s/@VERSION@/${version}/g" \
-            -e "s/@SHA256@/${source_sha}/g" \
-            packaging/aur/PKGBUILD.template > /tmp/PKGBUILD
-          bash -n /tmp/PKGBUILD
-          mkdir -p /tmp/aur-metadata
-          cp /tmp/PKGBUILD /tmp/aur-metadata/PKGBUILD
-          useradd -m builder
-          chown -R builder:builder /tmp/aur-metadata
-          runuser -u builder -- bash -lc 'cd /tmp/aur-metadata && makepkg --printsrcinfo > .SRCINFO'
-          test -s /tmp/aur-metadata/.SRCINFO
-
-      - name: Configure AUR SSH
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${AUR_SSH_PRIVATE_KEY:-}" ]]; then
-            echo '::error::Missing repository secret AUR_SSH_PRIVATE_KEY.'
-            exit 1
-          fi
-          mkdir -p /root/.ssh
-          chmod 700 /root/.ssh
-          printf '%s\n' "$AUR_SSH_PRIVATE_KEY" > /root/.ssh/id_aur
-          chmod 600 /root/.ssh/id_aur
-          ssh-keyscan -H aur.archlinux.org >> /root/.ssh/known_hosts
-          cat > /root/.ssh/config <<'EOF'
-          Host aur.archlinux.org
-            User aur
-            IdentityFile /root/.ssh/id_aur
-            IdentitiesOnly yes
-          EOF
-          chmod 600 /root/.ssh/config
-
-      - name: Push package to AUR
-        shell: bash
-        run: |
-          set -euo pipefail
-          version='${{ needs.validate-release.outputs.version }}'
-          git clone ssh://aur@aur.archlinux.org/riff.git /tmp/aur-repo
-          cp /tmp/aur-metadata/PKGBUILD /tmp/aur-repo/PKGBUILD
-          cp /tmp/aur-metadata/.SRCINFO /tmp/aur-repo/.SRCINFO
-          cd /tmp/aur-repo
-          git config user.name 'Riff Release Bot'
-          git config user.email 'Nicolas25vlad@users.noreply.github.com'
-          git add PKGBUILD .SRCINFO
-          if git diff --cached --quiet; then
-            echo "AUR is already at Riff $version; nothing to publish."
-            exit 0
-          fi
-          git commit -m "riff ${version}"
-          git push origin HEAD:master

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,11 +2,23 @@
 
 GitHub Releases are the source of truth for package publication.
 
-A published, non-prerelease GitHub Release with a tag such as `v0.6.0` triggers `.github/workflows/publish-packages.yml`, which publishes the matching version to crates.io and updates the AUR package.
+A published, non-prerelease GitHub Release with a tag such as `v0.6.0` triggers `.github/workflows/publish-packages.yml`, which publishes the matching version to crates.io.
 
-## One-time repository setup
+## Current package targets
 
 ### crates.io
+
+Active.
+
+```bash
+cargo install riff
+```
+
+### AUR
+
+Temporarily paused because new AUR account creation is currently unavailable. The `packaging/aur/PKGBUILD.template` is intentionally kept in the repository so AUR publishing can be re-enabled later, but no active CI or release workflow currently publishes to AUR.
+
+## One-time crates.io setup
 
 1. Sign in to crates.io with the GitHub account that will own the `riff` crate.
 2. Verify the crates.io account email.
@@ -19,20 +31,7 @@ CARGO_REGISTRY_TOKEN
 
 Never commit this token to the repository.
 
-### AUR
-
-1. Create/sign in to the AUR account that will maintain `riff`.
-2. Create a dedicated SSH key pair for the Riff release bot.
-3. Add the **public** key to the AUR account.
-4. Store the **private** key as the GitHub Actions secret:
-
-```text
-AUR_SSH_PRIVATE_KEY
-```
-
-The release workflow connects only to `aur.archlinux.org` and pushes `PKGBUILD` plus `.SRCINFO` to the `riff` AUR repository.
-
-## Release checklist
+## Normal release checklist
 
 1. Make sure `main` is green.
 2. Update the version in `Cargo.toml` using SemVer.
@@ -46,45 +45,46 @@ Git tag            = v0.7.0
 
 5. Create and **publish** a GitHub Release for that tag.
 6. Watch the `Publish Packages` workflow.
-7. Verify the new version on crates.io and AUR.
+7. Verify the new version on crates.io.
 
 The workflow deliberately aborts if the release tag does not equal `v${Cargo.toml version}`.
 
+## First crates.io bootstrap
+
+The first publication of Riff 0.6.0 uses `.github/workflows/publish-crates-bootstrap.yml` because the connected automation used to prepare the repository cannot create a GitHub Release directly.
+
+The bootstrap workflow:
+
+- only triggers when that workflow itself lands on `main`;
+- is pinned to version `0.6.0`;
+- requires `CARGO_REGISTRY_TOKEN`;
+- runs `cargo publish --dry-run` immediately before publication;
+- then runs the real `cargo publish`.
+
+After Riff 0.6.0 is verified on crates.io, remove the bootstrap workflow. Future versions use the normal GitHub Release workflow above.
+
 ## What CI validates before release
 
-`Package Check` runs on packaging-related pull requests and validates:
-
-- `cargo publish --dry-run` on Linux;
-- the AUR `PKGBUILD.template` in an Arch Linux container;
-- `.SRCINFO` generation with `makepkg --printsrcinfo`.
+`Package Check` runs on packaging-related pull requests and validates `cargo publish --dry-run` on Linux.
 
 The normal Riff CI still owns Rust formatting, Clippy, tests, cross-platform checks and CLI smoke tests.
 
-## AUR source of truth
+## Dormant AUR packaging
 
-Do not hand-maintain generated `PKGBUILD` or `.SRCINFO` files in this repository.
-
-The maintained file is:
+Do not hand-maintain generated `PKGBUILD` or `.SRCINFO` files in this repository. The dormant source template remains:
 
 ```text
 packaging/aur/PKGBUILD.template
 ```
 
-At release time the workflow injects:
-
-- the version from the release tag;
-- the SHA-256 of the immutable tagged source archive.
-
-Then it generates `.SRCINFO` with Arch's own tooling before pushing both files to AUR.
+When AUR publishing is re-enabled, restore CI validation and generate `.SRCINFO` with Arch's own tooling before pushing.
 
 ## Current reproducibility note
 
-Riff does not yet commit `Cargo.lock` (tracked in #13). Until that is fixed, crate/AUR builds resolve dependency versions during packaging. After #13 lands, release/package commands should be tightened to use `--locked` where supported.
+Riff does not yet commit `Cargo.lock` (tracked in #13). Until that is fixed, crate builds resolve dependency versions during packaging. After #13 lands, release/package commands should be tightened to use `--locked` where supported.
 
 ## Failure behavior
 
 A failed crates.io publish does not rewrite or delete an existing crates.io version. crates.io versions are immutable.
 
-An AUR publish only commits when the generated package metadata differs from the current AUR repository.
-
-If either registry credential is missing, the corresponding job exits with an explicit error instead of silently skipping publication.
+If the crates.io credential is missing, the publishing job exits with an explicit error instead of silently skipping publication.


### PR DESCRIPTION
Prepares the first crates.io release after #38.

- pauses AUR publishing and AUR package checks while account creation is unavailable
- keeps the dormant AUR template for later re-enablement
- keeps the permanent GitHub-Release -> crates.io workflow
- adds a one-shot bootstrap publisher for Riff 0.6.0 because the connected GitHub automation cannot create Releases directly
- bootstrap requires `CARGO_REGISTRY_TOKEN`, pins Cargo.toml to 0.6.0, performs a final `cargo publish --dry-run`, then publishes
- updates RELEASING.md with the temporary bootstrap process

This PR is intentionally the launch trigger: when merged into `main`, the bootstrap workflow runs once and attempts the real crates.io publication.