### PR TITLE
fix(release): publish Cargo package as riff-music

### DIFF
--- a/.github/workflows/publish-crates-bootstrap.yml
+++ b/.github/workflows/publish-crates-bootstrap.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   publish:
-    name: Publish Riff 0.6.0 to crates.io
+    name: Publish riff-music 0.6.0 to crates.io
     runs-on: ubuntu-latest
     timeout-minutes: 25
     env:
@@ -39,19 +39,24 @@ jobs:
             exit 1
           fi
 
-      - name: Validate bootstrap version
+      - name: Validate bootstrap package and version
         shell: bash
         run: |
           set -euo pipefail
+          package=$(sed -n 's/^name = "\([^"]*\)"/\1/p' Cargo.toml | head -n1)
           version=$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -n1)
+          if [[ "$package" != "riff-music" ]]; then
+            echo "::error::Bootstrap publisher expects package riff-music but Cargo.toml contains $package."
+            exit 1
+          fi
           if [[ "$version" != "0.6.0" ]]; then
             echo "::error::Bootstrap publisher is pinned to 0.6.0 but Cargo.toml contains $version."
             exit 1
           fi
-          echo "Publishing Riff $version"
+          echo "Publishing $package $version (binary: riff)"
 
       - name: Final crates.io dry run
         run: cargo publish --dry-run
 
       - name: Publish crates.io
-        run: cargo publish --token "$CARGO_REGISTRY_TOKEN"
+        run: cargo publish

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "riff"
+name = "riff-music"
 version = "0.6.0"
 edition = "2024"
 rust-version = "1.85"
@@ -12,6 +12,14 @@ keywords = ["music", "spotify", "terminal", "tui", "rust"]
 categories = ["command-line-utilities", "multimedia::audio"]
 publish = true
 exclude = [".github/**", "packaging/**", "scripts/**", "install.sh", "install.ps1"]
+
+[lib]
+name = "riff"
+path = "src/lib.rs"
+
+[[bin]]
+name = "riff"
+path = "src/main.rs"
 
 [dependencies]
 crossterm = "0.29"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -10,8 +10,11 @@ A published, non-prerelease GitHub Release with a tag such as `v0.6.0` triggers 
 
 Active.
 
+The application is called **Riff** and the installed executable is still `riff`, but the crates.io package is named `riff-music` because the `riff` package name is already owned by an unrelated crate.
+
 ```bash
-cargo install riff
+cargo install riff-music
+riff --version
 ```
 
 ### AUR
@@ -20,7 +23,7 @@ Temporarily paused because new AUR account creation is currently unavailable. Th
 
 ## One-time crates.io setup
 
-1. Sign in to crates.io with the GitHub account that will own the `riff` crate.
+1. Sign in to crates.io with the GitHub account that will own the `riff-music` crate.
 2. Verify the crates.io account email.
 3. Create an API token with permission to publish/update the crate.
 4. In this GitHub repository, create an Actions secret named:
@@ -51,17 +54,17 @@ The workflow deliberately aborts if the release tag does not equal `v${Cargo.tom
 
 ## First crates.io bootstrap
 
-The first publication of Riff 0.6.0 uses `.github/workflows/publish-crates-bootstrap.yml` because the connected automation used to prepare the repository cannot create a GitHub Release directly.
+The first publication of `riff-music` 0.6.0 uses `.github/workflows/publish-crates-bootstrap.yml` because the connected automation used to prepare the repository cannot create a GitHub Release directly.
 
 The bootstrap workflow:
 
 - only triggers when that workflow itself lands on `main`;
-- is pinned to version `0.6.0`;
+- is pinned to package `riff-music` version `0.6.0`;
 - requires `CARGO_REGISTRY_TOKEN`;
 - runs `cargo publish --dry-run` immediately before publication;
 - then runs the real `cargo publish`.
 
-After Riff 0.6.0 is verified on crates.io, remove the bootstrap workflow. Future versions use the normal GitHub Release workflow above.
+After `riff-music` 0.6.0 is verified on crates.io, remove the bootstrap workflow. Future versions use the normal GitHub Release workflow above.
 
 ## What CI validates before release
 


### PR DESCRIPTION
The crates.io name `riff` is already owned by an unrelated RIFF/WAV library, so this keeps the application and executable named `riff` while publishing the Cargo package as `riff-music`.

- package name: `riff-music`
- library crate name: `riff`
- installed binary: `riff`
- install command: `cargo install riff-music`
- updates the one-shot 0.6.0 bootstrap publisher and release docs

This PR should pass normal CI and Package Check before merge. Merging it intentionally retriggers the first crates.io publication attempt.