### PR TITLE
chore(release): prepare v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable user-facing changes to Riff are documented here.
 
+## 0.6.2
+
+### Changed
+
+- refreshed README and installation docs around the current Workbench and crates.io package;
+- exposed the primary `riff tui <file>` command in `riff help`;
+- added a regression test so the Workbench command cannot silently disappear from CLI help;
+- added this project changelog as the release-history source of truth.
+
 ## 0.6.1
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riff-music"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 rust-version = "1.85"
 description = "A terminal-first music player where playlists are code."


### PR DESCRIPTION
Final version bump after the v0.6.1 GitHub release was found to already exist.

## Changes
- bump `riff-music` from 0.6.1 to 0.6.2
- add v0.6.2 CHANGELOG notes for the pre-release README/install/help polish

No additional runtime changes. Merge only after normal CI, TUI quality gate and package dry-run are green.