### PR TITLE
fix(release): make v0.6.3 dispatch chain reliable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,22 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag to publish, for example v0.6.3
+        required: true
+        type: string
 
 permissions:
   contents: write
 
 concurrency:
-  group: release-${{ github.ref_name }}
+  group: release-${{ inputs.tag || github.ref_name }}
   cancel-in-progress: false
+
+env:
+  RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
 
 jobs:
   validate:
@@ -21,6 +30,8 @@ jobs:
     steps:
       - name: Checkout tag
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Validate tag matches Cargo.toml
         id: version
@@ -29,8 +40,8 @@ jobs:
           set -euo pipefail
           version=$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -n1)
           test -n "$version"
-          if [[ "${GITHUB_REF_NAME}" != "v${version}" ]]; then
-            echo "::error::Tag ${GITHUB_REF_NAME} does not match Cargo.toml version ${version}."
+          if [[ "${RELEASE_TAG}" != "v${version}" ]]; then
+            echo "::error::Tag ${RELEASE_TAG} does not match Cargo.toml version ${version}."
             exit 1
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
@@ -52,6 +63,8 @@ jobs:
     steps:
       - name: Checkout tag
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Install Linux audio dependencies
         if: runner.os == 'Linux'
@@ -115,6 +128,8 @@ jobs:
     steps:
       - name: Checkout tag
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Download release files
         uses: actions/download-artifact@v4
@@ -148,8 +163,42 @@ EOF
         shell: bash
         run: |
           set -euo pipefail
-          gh release create "${GITHUB_REF_NAME}" dist/* \
+          gh release create "${RELEASE_TAG}" dist/* \
             --repo "${GITHUB_REPOSITORY}" \
-            --title "Riff ${GITHUB_REF_NAME}" \
+            --title "Riff ${RELEASE_TAG}" \
             --notes-file release-notes.md \
             --verify-tag
+
+  crates-io:
+    name: Publish crates.io
+    needs: [validate, github-release]
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+    steps:
+      - name: Checkout tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+
+      - name: Install Linux audio dependencies
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev libpulse-dev pkg-config
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Require crates.io token
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "${CARGO_REGISTRY_TOKEN:-}" || { echo '::error::Missing CARGO_REGISTRY_TOKEN'; exit 1; }
+
+      - name: Final crates.io dry run
+        run: cargo publish --dry-run
+
+      - name: Publish crates.io
+        run: cargo publish

--- a/.github/workflows/trigger-v0.6.3.yml
+++ b/.github/workflows/trigger-v0.6.3.yml
@@ -8,26 +8,36 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
-  tag:
+  tag-and-dispatch:
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout main
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Create v0.6.3 tag
+      - name: Ensure v0.6.3 tag exists
         shell: bash
         run: |
           set -euo pipefail
           test "$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -n1)" = "0.6.3"
-          if git rev-parse refs/tags/v0.6.3 >/dev/null 2>&1; then
-            echo "v0.6.3 already exists"
-            exit 0
+          if ! git rev-parse refs/tags/v0.6.3 >/dev/null 2>&1; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git tag -a v0.6.3 -m "Riff v0.6.3"
+            git push origin v0.6.3
           fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a v0.6.3 -m "Riff v0.6.3"
-          git push origin v0.6.3
+
+      - name: Dispatch permanent release workflow
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh workflow run release.yml \
+            --repo "${GITHUB_REPOSITORY}" \
+            --ref main \
+            -f tag=v0.6.3


### PR DESCRIPTION
Fixes the GitHub Actions recursion guard discovered during the v0.6.3 launch.

GitHub does not start a second workflow from a tag pushed with the repository GITHUB_TOKEN. This change:
- adds `workflow_dispatch` support to the permanent Release workflow
- lets the one-shot v0.6.3 trigger explicitly dispatch that workflow
- checks out the requested release tag in every release job
- publishes crates.io from the same Release workflow after GitHub Release creation, avoiding reliance on a release event emitted by GITHUB_TOKEN

The existing Publish Packages workflow remains as a fallback for manually published GitHub Releases.