### PR TITLE
chore(release): run self-contained v0.6.3 publisher

### DIFF
--- a/.github/workflows/trigger-v0.6.3.yml
+++ b/.github/workflows/trigger-v0.6.3.yml
@@ -1,4 +1,4 @@
-name: Trigger v0.6.3
+name: Release v0.6.3 one-shot
 
 on:
   push:
@@ -8,36 +8,191 @@ on:
 
 permissions:
   contents: write
-  actions: write
+
+concurrency:
+  group: release-v0.6.3-one-shot
+  cancel-in-progress: false
 
 jobs:
-  tag-and-dispatch:
+  validate:
+    name: Validate v0.6.3
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          ref: v0.6.3
+
+      - name: Validate tag version
+        shell: bash
+        run: |
+          set -euo pipefail
+          version=$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -n1)
+          test "$version" = "0.6.3"
+
+  build:
+    name: Build ${{ matrix.name }}
+    needs: validate
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux x86_64
+            os: ubuntu-latest
+            artifact: riff-linux-x86_64
+          - name: Windows x86_64
+            os: windows-latest
+            artifact: riff-windows-x86_64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          ref: v0.6.3
+
+      - name: Install Linux audio dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev libpulse-dev pkg-config
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build release binary
+        run: cargo build --release
+
+      - name: Package Linux binary
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          cp target/release/riff dist/riff
+          tar -C dist -czf riff-0.6.3-linux-x86_64.tar.gz riff
+          sha256sum riff-0.6.3-linux-x86_64.tar.gz > riff-0.6.3-linux-x86_64.tar.gz.sha256
+
+      - name: Package Windows binary
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path dist | Out-Null
+          Copy-Item target/release/riff.exe dist/riff.exe
+          Compress-Archive -Path dist/riff.exe -DestinationPath riff-0.6.3-windows-x86_64.zip -Force
+          $hash = (Get-FileHash riff-0.6.3-windows-x86_64.zip -Algorithm SHA256).Hash.ToLower()
+          "$hash  riff-0.6.3-windows-x86_64.zip" | Set-Content riff-0.6.3-windows-x86_64.zip.sha256
+
+      - name: Upload Linux files
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: |
+            riff-0.6.3-linux-x86_64.tar.gz
+            riff-0.6.3-linux-x86_64.tar.gz.sha256
+          if-no-files-found: error
+
+      - name: Upload Windows files
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: |
+            riff-0.6.3-windows-x86_64.zip
+            riff-0.6.3-windows-x86_64.zip.sha256
+          if-no-files-found: error
+
+  github-release:
+    name: Publish GitHub Release
+    needs: build
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - name: Checkout main
+      - name: Checkout release tag
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          ref: v0.6.3
 
-      - name: Ensure v0.6.3 tag exists
+      - name: Download release files
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Build release notes
         shell: bash
         run: |
           set -euo pipefail
-          test "$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -n1)" = "0.6.3"
-          if ! git rev-parse refs/tags/v0.6.3 >/dev/null 2>&1; then
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git tag -a v0.6.3 -m "Riff v0.6.3"
-            git push origin v0.6.3
+          awk '
+            $0 == "## 0.6.3" { capture=1; next }
+            capture && /^## / { exit }
+            capture { print }
+          ' CHANGELOG.md > release-notes.md
+          test -s release-notes.md
+          cat >> release-notes.md <<'EOF'
+
+### Install / upgrade
+
+```bash
+cargo install riff-music --force
+```
+
+Spotify playback requires Spotify Premium.
+EOF
+
+      - name: Create GitHub Release
+        shell: bash
+        run: |
+          set -euo pipefail
+          if gh release view v0.6.3 --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "v0.6.3 release already exists"
+            exit 0
           fi
+          gh release create v0.6.3 dist/* \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "Riff v0.6.3" \
+            --notes-file release-notes.md \
+            --verify-tag
 
-      - name: Dispatch permanent release workflow
+  crates-io:
+    name: Publish crates.io
+    needs: github-release
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          ref: v0.6.3
+
+      - name: Install Linux audio dependencies
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev libpulse-dev pkg-config
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Require crates.io token
         shell: bash
         run: |
           set -euo pipefail
-          gh workflow run release.yml \
-            --repo "${GITHUB_REPOSITORY}" \
-            --ref main \
-            -f tag=v0.6.3
+          test -n "${CARGO_REGISTRY_TOKEN:-}" || { echo '::error::Missing CARGO_REGISTRY_TOKEN'; exit 1; }
+
+      - name: Final crates.io dry run
+        run: cargo publish --dry-run
+
+      - name: Publish crates.io
+        shell: bash
+        run: |
+          set -euo pipefail
+          if cargo search riff-music --limit 1 | grep -q '^riff-music = "0.6.3"'; then
+            echo "riff-music 0.6.3 is already published"
+            exit 0
+          fi
+          cargo publish


### PR DESCRIPTION
One-shot publisher for the already-created `v0.6.3` tag.

The nested workflow-dispatch route is blocked by GitHub's workflow registration/recursion behavior, so this temporary workflow performs the complete release in one run:
- validates the existing v0.6.3 tag
- builds release binaries on Linux and Windows
- packages archives + SHA-256 checksums
- creates the GitHub Release from CHANGELOG
- performs a final crates.io dry run and publishes riff-music 0.6.3

It will be removed after publication succeeds.