### PR TITLE
fix(release): repair v0.6.3 and permanent workflow YAML

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,14 +150,14 @@ jobs:
           test -s release-notes.md
           cat >> release-notes.md <<'EOF'
 
-### Install / upgrade
+          ### Install / upgrade
 
-```bash
-cargo install riff-music --force
-```
+          ```bash
+          cargo install riff-music --force
+          ```
 
-Spotify playback requires Spotify Premium.
-EOF
+          Spotify playback requires Spotify Premium.
+          EOF
 
       - name: Publish GitHub Release
         shell: bash

--- a/.github/workflows/trigger-v0.6.3.yml
+++ b/.github/workflows/trigger-v0.6.3.yml
@@ -133,14 +133,14 @@ jobs:
           test -s release-notes.md
           cat >> release-notes.md <<'EOF'
 
-### Install / upgrade
+          ### Install / upgrade
 
-```bash
-cargo install riff-music --force
-```
+          ```bash
+          cargo install riff-music --force
+          ```
 
-Spotify playback requires Spotify Premium.
-EOF
+          Spotify playback requires Spotify Premium.
+          EOF
 
       - name: Create GitHub Release
         shell: bash


### PR DESCRIPTION
Fixes the workflow parser failure discovered during v0.6.3 release.

Root cause: the Markdown heredoc used to append install notes was not indented inside the YAML block scalar, so GitHub could not parse either the permanent Release workflow or the temporary v0.6.3 publisher.

This PR:
- fixes heredoc indentation in `.github/workflows/release.yml`
- fixes the temporary v0.6.3 one-shot publisher
- keeps v0.6.3 release jobs self-contained: Linux build, Windows build, GitHub Release, crates.io

No Rust application code changes.